### PR TITLE
core: Create an X.Org requirement.

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -94,7 +94,7 @@ class DependencyCollector
 
   def parse_symbol_spec(spec, tags)
     case spec
-    when :x11        then X11Requirement.new(spec.to_s, tags)
+    when :x11        then OS.mac? ? X11Requirement.new(spec.to_s, tags) : XorgRequirement.new(spec.to_s, tags)
     when :xcode      then XcodeRequirement.new(tags)
     when :macos      then MinimumMacOSRequirement.new(tags)
     when :mysql      then MysqlRequirement.new(tags)

--- a/Library/Homebrew/os/mac/xquartz.rb
+++ b/Library/Homebrew/os/mac/xquartz.rb
@@ -30,7 +30,6 @@ module OS
       # The X11.app distributed by Apple is also XQuartz, and therefore covered
       # by this method.
       def version
-        @version ||= latest_version if OS.linux?
         @version ||= detect_version
       end
 
@@ -96,7 +95,6 @@ module OS
       # remain public. New code should use MacOS::X11.bin, MacOS::X11.lib and
       # MacOS::X11.include instead, as that accounts for Xcode-only systems.
       def prefix
-        @prefix ||= Pathname.new("/usr") if OS.linux?
         @prefix ||= if Pathname.new("/opt/X11/lib/libpng.dylib").exist?
           Pathname.new("/opt/X11")
         elsif Pathname.new("/usr/X11/lib/libpng.dylib").exist?

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -13,6 +13,7 @@ require "requirements/ruby_requirement"
 require "requirements/tuntap_requirement"
 require "requirements/unsigned_kext_requirement"
 require "requirements/x11_requirement"
+require "requirements/xorg_requirement"
 require "requirements/emacs_requirement"
 require "requirements/glibc_requirement"
 

--- a/Library/Homebrew/requirements/xorg_requirement.rb
+++ b/Library/Homebrew/requirements/xorg_requirement.rb
@@ -1,0 +1,18 @@
+require "requirement"
+
+class XorgRequirement < Requirement
+  fatal true
+  default_formula "linuxbrew/xorg/xorg"
+
+  def initialize(name = "xorg", tags = [])
+    @name = name
+    if /(\d\.)+\d/ === tags.first
+      tags.shift
+    end
+    super(tags)
+  end
+
+  satisfy :build_env => false do
+    Formula["linuxbrew/xorg/xorg"].installed?
+  end
+end

--- a/Library/Homebrew/test/test_dependency_collector.rb
+++ b/Library/Homebrew/test/test_dependency_collector.rb
@@ -39,7 +39,8 @@ class DependencyCollectorTests < Homebrew::TestCase
 
   def test_requirement_creation
     @d.add :x11
-    assert_instance_of X11Requirement, find_requirement(X11Requirement)
+    req = OS.mac? ? X11Requirement : XorgRequirement
+    assert_instance_of req, find_requirement(req)
   end
 
   def test_no_duplicate_requirements
@@ -50,29 +51,34 @@ class DependencyCollectorTests < Homebrew::TestCase
   def test_requirement_tags
     @d.add :x11 => "2.5.1"
     @d.add :xcode => :build
-    assert_empty find_requirement(X11Requirement).tags
+    req = OS.mac? ? X11Requirement : XorgRequirement
+    assert_empty find_requirement(req).tags
     assert_predicate find_requirement(XcodeRequirement), :build?
   end
 
   def test_x11_no_tag
     @d.add :x11
-    assert_empty find_requirement(X11Requirement).tags
+    req = OS.mac? ? X11Requirement : XorgRequirement
+    assert_empty find_requirement(req).tags
   end
 
   def test_x11_min_version
+    skip "XQuartz versions are relevant only on Mac OS" unless OS.mac?
     @d.add :x11 => "2.5.1"
     assert_equal "2.5.1", find_requirement(X11Requirement).min_version.to_s
   end
 
   def test_x11_tag
     @d.add :x11 => :optional
-    assert_predicate find_requirement(X11Requirement), :optional?
+    req = OS.mac? ? X11Requirement : XorgRequirement
+    assert_predicate find_requirement(req), :optional?
   end
 
   def test_x11_min_version_and_tag
     @d.add :x11 => ["2.5.1", :optional]
-    dep = find_requirement(X11Requirement)
-    assert_equal "2.5.1", dep.min_version.to_s
+    req = OS.mac? ? X11Requirement : XorgRequirement
+    dep = find_requirement(req)
+    assert_equal "2.5.1", dep.min_version.to_s if OS.mac?
     assert_predicate dep, :optional?
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully ran `brew tests` with your changes locally?

The existing X11 requirement only works for OS X, and works in concert
with XQuartz. For Linux, we want to install upstream X.Org instead.
