### PR TITLE
dependency_collector: Fix ant_dep for Linuxbrew.

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -135,7 +135,7 @@ class DependencyCollector
   end
 
   def ant_dep(spec, tags)
-    if MacOS.version >= :mavericks
+    if MacOS.version >= :mavericks || !OS.mac?
       Dependency.new(spec.to_s, tags)
     end
   end

--- a/Library/Homebrew/test/test_dependency_collector.rb
+++ b/Library/Homebrew/test/test_dependency_collector.rb
@@ -87,6 +87,26 @@ class DependencyCollectorTests < Homebrew::TestCase
     assert_nil @d.build(:ld64)
   end
 
+  def test_ant_dep_mavericks_or_newer
+    skip "Only for Mac OS" unless OS.mac?
+    MacOS.stubs(:version).returns(MacOS::Version.new("10.9"))
+    @d.add :ant => :build
+    assert_equal find_dependency("ant"), Dependency.new("ant", [:build])
+  end
+
+  def test_ant_dep_pre_mavericks
+    skip "Only for Mac OS" unless OS.mac?
+    MacOS.stubs(:version).returns(MacOS::Version.new("10.7"))
+    @d.add :ant => :build
+    assert_nil find_dependency("ant")
+  end
+
+  def test_ant_non_mac
+    skip "Does not apply to Mac OS" if OS.mac?
+    @d.add :ant => :build
+    assert_equal find_dependency("ant"), Dependency.new("ant", [:build])
+  end
+
   def test_raises_typeerror_for_unknown_classes
     assert_raises(TypeError) { @d.add(Class.new) }
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully ran `brew tests` with your changes locally?

The ant_dep previously didn't work on Linuxbrew, since it was checking only that the OS X version was Mavericks or newer.
