### PR TITLE
build-bottle-pr: Use fully specified base and head for PR

### DIFF
--- a/Library/Homebrew/dev-cmd/build-bottle-pr.rb
+++ b/Library/Homebrew/dev-cmd/build-bottle-pr.rb
@@ -22,10 +22,12 @@ module Homebrew
       f.write "# #{message}\n#{s}"
     end
     branch = "bottle-#{formula}"
+    base = "linuxbrew:master"
+    head = "#{remote}:#{branch}"
     safe_system "git", "checkout", "-b", branch, "master"
     safe_system "git", "commit", formula.path, "-m", message
     safe_system "git", "push", remote, branch
-    safe_system "hub", "pull-request", "--browse", "-m", message
+    safe_system "hub", "pull-request", "-b", base, "-h", head, "--browse", "-m", message
     safe_system "git", "checkout", "master"
     safe_system "git", "branch", "-D", branch
   end


### PR DESCRIPTION
This should help with `hub` exiting with:

```
Error creating pull request: Unprocessable Entity (HTTP 422)
Missing field: "head_sha"
Missing field: "base_sha"
No commits between master and bottle-msgpack
```
