### PR TITLE
pull: Fix fetching of x86_64_linux bottles

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -516,7 +516,11 @@ module Homebrew
           opoo "Cannot publish bottle: Failed reading info for formula #{f.full_name}"
           next
         end
-        bottle_info = jinfo.bottle_info(jinfo.bottle_tags.first)
+        if f.tap.remote.include?("Linuxbrew") && jinfo.bottle_tags.include?("x86_64_linux")
+          bottle_info = jinfo.bottle_info("x86_64_linux")
+        else
+          bottle_info = jinfo.bottle_info(jinfo.bottle_tags.first)
+        end
         unless bottle_info
           opoo "No bottle defined in formula #{f.full_name}"
           next


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

---

If the tap you're pulling from includes "Linuxbrew" in its name and the formula has an x86_64_linux bottle, use that one. Otherwise, fall back to Homebrew's default behaviour.

Previously, we were verifying by downloading the first bottle in the list, but since that's usually a Mac bottle, the download will fail.
