### PR TITLE
Set DEFAULT_FLAGS to -march=native for Linuxbrew

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -8,7 +8,7 @@ module Stdenv
 
   # @private
   SAFE_CFLAGS_FLAGS = "-w -pipe"
-  DEFAULT_FLAGS = "-march=core2 -msse4"
+  DEFAULT_FLAGS = OS.mac? ? "-march=core2 -msse4" : "-march=native"
 
   def self.extended(base)
     unless ORIGINAL_PATHS.include? HOMEBREW_PREFIX/"bin"
@@ -372,7 +372,7 @@ module Stdenv
   def effective_arch
     if ARGV.build_bottle?
       ARGV.bottle_arch || Hardware.oldest_cpu
-    elsif Hardware::CPU.intel? && !Hardware::CPU.sse4?
+    elsif OS.mac? && Hardware::CPU.intel? && !Hardware::CPU.sse4?
       # If the CPU doesn't support SSE4, we cannot trust -march=native or
       # -march=<cpu family> to do the right thing because we might be running
       # in a VM or on a Hackintosh.


### PR DESCRIPTION
Fix run-time illegal instruction errors on older machines.

Closes Linuxbrew/linuxbrew#1053.
Closes Linuxbrew/linuxbrew#1094.
