### PR TITLE
Listing only unique dependencies of packages

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -125,7 +125,7 @@ module Homebrew
       chr = i == max ? "└──" : "├──"
       puts prefix + "#{chr} :#{req.to_dependency.name}"
     end
-    deps = f.deps.default
+    deps = f.deps.default.uniq
     max = deps.length - 1
     deps.each_with_index do |dep, i|
       chr = i == max ? "└──" : "├──"


### PR DESCRIPTION
Small change => big consequences. 
Before the patch:

```
$ brew deps --tree docbook
docbook (required dependencies)
├── homebrew/dupes/unzip
├── homebrew/dupes/unzip
├── homebrew/dupes/unzip
├── homebrew/dupes/unzip
├── homebrew/dupes/unzip
├── homebrew/dupes/unzip
└── homebrew/dupes/unzip
```

After the patch:

```
$ brew deps --tree docbook
docbook (required dependencies)
└── homebrew/dupes/unzip
```
