### PR TITLE
brew.sh: only hard code HOMEBREW_CURL when it is empty

### DIFF
--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -81,7 +81,7 @@ then
   fi
 fi
 
-HOMEBREW_CURL="/usr/bin/curl"
+[[ -z "$HOMEBREW_CURL" ]] && HOMEBREW_CURL="/usr/bin/curl"
 if [[ -n "$HOMEBREW_OSX" ]]
 then
   HOMEBREW_PROCESSOR="$(uname -p)"


### PR DESCRIPTION
Users should be given a chance to choose their version of curl. It is escpectially important when the system `/usr/bin/curl` is too old.
