### PR TITLE
xquartz: Fix prefix for Linuxbrew

### DIFF
--- a/Library/Homebrew/os/mac/xquartz.rb
+++ b/Library/Homebrew/os/mac/xquartz.rb
@@ -102,6 +102,8 @@ module OS
         # X11 doesn't include libpng on Tiger
         elsif Pathname.new("/usr/X11R6/lib/libX11.dylib").exist?
           Pathname.new("/usr/X11R6")
+        elsif OS.linux?
+          HOMEBREW_PREFIX
         end
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

---

Setting the prefix to be HOMEBREW_PREFIX since on Linuxbrew X11 dependencies have a default dependency on `linuxbrew/linuxbrew/xorg`.

Fixes #52.
