### PR TITLE
development_tools: Make GCC always be the default compiler on Linux

### DIFF
--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -25,6 +25,7 @@ class DevelopmentTools
     end
 
     def default_compiler
+      return :gcc unless OS.mac?
       case default_cc
       # if GCC 4.2 is installed, e.g. via Tigerbrew, prefer it
       # over the system's GCC 4.0


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

---

For systems like Ubuntu that use hardening-wrapper as the default GCC, `DevelopmentTools.default_compiler` will assume Clang is the default, causing test failures.

Fix test:
TabTests#test_defaults [$PREFIX/Library/Homebrew/test/test_tab.rb:35]

Closes linuxbrew/brew#69
