### PR TITLE
patch_rpath: Do not relocate static executables

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -294,6 +294,18 @@ class Pathname
   end
 
   # @private
+  def elf?
+    @which_file ||= which("file")
+    !@which_file.nil? && `#{@which_file} -b #{self}` =~ /^ELF/
+  end
+
+  # @private
+  def dynamic?
+    @which_file ||= which("file")
+    !@which_file.nil? && `#{@which_file} -b #{self}` =~ /dynamically linked/
+  end
+
+  # @private
   def text_executable?
     /^#!\s*\S+/ === open("r") { |f| f.read(1024) }
   end

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -76,7 +76,7 @@ class Keg
   end
 
   def change_rpath(file, old_prefix, new_prefix)
-    return unless OS.linux?
+    return unless OS.linux? && file.elf? && file.dynamic?
     # Patching patchelf using itself fails with "Text file busy" or SIGBUS.
     return if name == "patchelf"
     begin


### PR DESCRIPTION
Static executables do not need to be relocated,
and patchelf fails on them.

Fixes Linuxbrew/brew#4.
