### PR TITLE
bottle: Extend DSL allow cellar force_skip_relocation

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -324,6 +324,8 @@ class BottleSpecification
 
   # Does the Bottle this BottleSpecification belongs to need to be relocated?
   def skip_relocation?
+    # Allow bottles to skip at their own peril with force-skip-relocation.
+    return true if cellar == :force_skip_relocation
     # Relocation is always required on Linux to locate glibc.
     return false if OS.linux?
     cellar == :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

---

This extends the bottle DSL to include `:force_skip_relocation` as a potential `cellar` directive.

Currently, Linux prevents the bottle definition from skipping relocation. For customized OSes with multiple `glibc` runtimes, skipping the linker override is necessary.

See #86.
