### PR TITLE
brew: fix for systems having non-standard bash

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/bin/sh
+if [ -z "$BASH_VERSION" ]
+then
+  exec bash "$0" "$@"
+fi
 set +o posix
 
 quiet_cd() {


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

---

This change allows `brew` to run on systems that have `bash` installed in non-standard location (like `/usr/bin/bash`)
