### PR TITLE
Add merom to supported architectures

### DIFF
--- a/Library/Homebrew/test/test_hardware.rb
+++ b/Library/Homebrew/test/test_hardware.rb
@@ -7,7 +7,7 @@ class HardwareTests < Homebrew::TestCase
   end
 
   def test_hardware_intel_family
-    families = [:core, :core2, :penryn, :nehalem, :arrandale, :sandybridge, :ivybridge, :haswell, :broadwell, :skylake, :dunno]
+    families = [:core, :core2, :merom, :penryn, :nehalem, :arrandale, :sandybridge, :ivybridge, :haswell, :broadwell, :skylake, :dunno]
     assert_includes families, Hardware::CPU.family
   end
 end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

---

https://en.wikipedia.org/wiki/Merom_(microprocessor) (Other thing is my CPU is Kentsfield according to https://en.wikipedia.org/wiki/List_of_Intel_Core_2_microprocessors#Core_2_Quad but somehow recognized as Merom...)
