### PR TITLE
build-bottle-pr: Skip if you have uncommited changes to a tap

### DIFF
--- a/Library/Homebrew/dev-cmd/build-bottle-pr.rb
+++ b/Library/Homebrew/dev-cmd/build-bottle-pr.rb
@@ -36,11 +36,17 @@ module Homebrew
     @@n += 1
     return ohai "#{@@n}. #{formula}: Skipping because GitHub rate limits pull requests" if @@n > limit
 
+    tap_dir = formula.tap.formula_dir
+    cd tap_dir
+
+    unless `git status --untracked-files=all --porcelain 2>/dev/null`.chomp.empty?
+      return ohai "#{formula}: Skipping because you have uncommitted changes to #{tap_dir}"
+    end
+
     message = "#{formula}: Build a bottle for Linuxbrew"
     oh1 "#{@@n}. #{message}"
     return if ARGV.dry_run?
 
-    cd formula.tap.formula_dir
     File.open(formula.path, "r+") do |f|
       s = f.read
       f.rewind


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally? IN PROGRESS

---

This skips building a bottle if you have uncommitted changes to the tap a formula is in. This has bitten me way too many times, and it's a pain to go and do the multiple steps necessary to correct it (stash, delete branch, push branch deletion, switch back to master branch, etc.)
