### PR TITLE
.gitignore: Don't ignore the Dockerfile or docker.test.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@
 !/CODEOFCONDUCT.md
 !/LICENSE.txt
 !/README.md
+!/Dockerfile
+!/docker.test.yml


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

---

The Homebrew uninstall script scans the .gitignore file for lines with
a "!" on them, and uses those to help determine what files to delete.
Since upstream's .gitignore does not contain "!Dockerfile" or
"!docker.test.yml", those two files are not recognized by the uninstall
script, which leads to failure.
