### PR TITLE
Fix exception when trying to find "file" when installing and it's not present

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -63,7 +63,7 @@ class Keg
   def text_files
     text_files = []
     which_file = OS.mac? ? "/usr/bin/file" : which("file")
-    return text_files unless File.exist?(which_file)
+    return text_files unless which_file && File.exist?(which_file)
 
     # file has known issues with reading files on other locales. Has
     # been fixed upstream for some time, but a sufficiently new enough


### PR DESCRIPTION
When "file" it's not installed in the OS (which is uncommon), it attempts to check for the existence of a `nil` variable, throwing "Error: no implicit conversion of nil into String" when pouring.

Note that this doesn't apply to Homebrew, as the value is a hardcoded string, which will never be `nil`: https://github.com/Homebrew/brew/blob/master/Library/Homebrew/keg_relocate.rb#L68
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?
