### PR TITLE
update.sh: prevent error with git versions <2.0

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -217,7 +217,9 @@ merge_or_rebase() {
 
   if [[ "$DIR" = "$HOMEBREW_REPOSITORY" && -z "$HOMEBREW_NO_UPDATE_CLEANUP" ]]
   then
-    UPSTREAM_TAG="$(git tag --list --sort=-version:refname | grep '^[0-9]*\.[0-9]*\.[0-9]*$' | head -n1)"
+    UPSTREAM_TAG="$(git tag --list |
+                    sort --field-separator=. --key=1,1nr -k 2,2nr -k 3,3nr |
+                    grep --max-count=1 '^[0-9]*\.[0-9]*\.[0-9]*$')"
   else
     UPSTREAM_TAG=""
   fi


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?

---

Currently, when installing linuxbrew `brew tap homebrew/core` throws

```
error: unknown option `sort=-version:refname'
```

 because `git tag` doesn't know `--sort` with git versions <2.0. This changes it to the same as in the main homebrew repo, which uses the `sort` and `grep` commands to sort the tags.
