### PR TITLE
squash-bottle-pr: Fix for GNU sed

### DIFF
--- a/Library/Homebrew/dev-cmd/squash-bottle-pr.rb
+++ b/Library/Homebrew/dev-cmd/squash-bottle-pr.rb
@@ -13,7 +13,11 @@ module Homebrew
     marker = "Build a bottle for Linuxbrew"
     safe_system "git", "reset", "--hard", "HEAD~2"
     safe_system "git", "merge", "--squash", head
-    safe_system "sed", "-i", "", "-e", "/^#.*: #{marker}$/d", file
+
+    # HACK: achieve compatibility between BSD and GNU sed
+    # by using a dummy backup and then deleting it
+    safe_system "sed", "-iorig", "-e", "/^#.*: #{marker}$/d", file
+    rm_f file.to_s + "orig"
 
     git_editor = ENV["GIT_EDITOR"]
     ENV["GIT_EDITOR"] = "sed -n -i -e 's/.*#{marker}//p;s/^    //p'"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

---

Use a hack to achieve compatibility between GNU and BSD sed's
-i option. Both of them accept the -i option, but GNU doesn't like
empty-string arguments to it. Specify a backup suffix and then
delete the resulting file instead.
