### PR TITLE
Close temp file before rename in atomic_write, fixes #146

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -179,6 +179,7 @@ class Pathname
       rescue Errno::EPERM
       end
 
+      tf.close
       File.rename(tf.path, self)
     ensure
       tf.close!


### PR DESCRIPTION
I'm not sure _why_ my specific NFS configuration couldn't handle renaming an open file - but it made all package installation impossible. With this change everything works fine.
