### PR TITLE
Add more paths to find the system Glibc

### DIFF
--- a/Library/Homebrew/requirements/glibc_requirement.rb
+++ b/Library/Homebrew/requirements/glibc_requirement.rb
@@ -13,7 +13,7 @@ class GlibcRequirement < Requirement
 
   def self.system_version
     return @system_version if @system_version
-    libc = ["/lib/x86_64-linux-gnu/libc.so.6", "/lib64/libc.so.6", "/lib/libc.so.6", "/lib/i386-linux-gnu/libc.so.6", "/lib/arm-linux-gnueabihf/libc.so.6"].find { |s|
+    libc = ["/lib/x86_64-linux-gnu/libc.so.6", "/lib64/libc.so.6", "/usr/lib64/libc.so.6", "/lib/libc.so.6", "/lib/i386-linux-gnu/libc.so.6", "/lib/arm-linux-gnueabihf/libc.so.6"].find { |s|
       Pathname.new(s).executable?
     }
     raise "Unable to locate the system's glibc" unless libc


### PR DESCRIPTION
I was trying to install Linuxbrew on [Solus OS](https://solus-project.com/), but Linuxbrew didn't seem to find the system Glibc. Apparently Solus keeps `libc.so.6` in `/usr/lib`, which is not a place checked by the `GlibcRequirement` requirement.
Is there a reason for not looking up in `/usr/lib` and `/usr/lib64` ?