### PR TITLE
std_cmake_args: Do not change RPATH for Linuxbrew

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1271,8 +1271,6 @@ class Formula
       -DCMAKE_VERBOSE_MAKEFILE=ON
       -Wno-dev
     ]
-    # Set RPATH for Linux to fix error while loading shared libraries
-    args += ["-DCMAKE_BUILD_WITH_INSTALL_RPATH=1", "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=1"] if OS.linux?
 
     # Avoid false positives for clock_gettime support on 10.11.
     # CMake cache entries for other weak symbols may be added here as needed.


### PR DESCRIPTION
Revert 9875b9154e792e622f5ac8fcbeb17709c3c84d13
and 07c7f4407afa278e9e017aeb030a0f663899d17f

Set neither -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=1
nor -DCMAKE_BUILD_WITH_INSTALL_RPATH=1.

Fixes https://github.com/Linuxbrew/brew/issues/171