### PR TITLE
dependency_collector: Add public Linux definitions for ant_dep and xz_dep

### DIFF
--- a/Library/Homebrew/extend/os/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/dependency_collector.rb
@@ -1,2 +1,3 @@
 require "dependency_collector"
 require "extend/os/mac/dependency_collector" if OS.mac?
+require "extend/os/linux/dependency_collector" if OS.linux?

--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -1,0 +1,9 @@
+class DependencyCollector
+  def ant_dep(tags)
+    Dependency.new("ant", tags)
+  end
+
+  def xz_dep(tags)
+    Dependency.new("xz", tags)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

