### PR TITLE
dependency_collector: Make ant_dep and xz_dep public

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -61,6 +61,14 @@ class DependencyCollector
     parse_spec(spec, Array(tags))
   end
 
+  def ant_dep(tags)
+    Dependency.new("ant", tags)
+  end
+
+  def xz_dep(tags)
+    Dependency.new("xz", tags)
+  end
+
   def self.tar_needs_xz_dependency?
     !new.xz_dep([]).nil?
   end
@@ -136,14 +144,6 @@ class DependencyCollector
     end
 
     spec.new(tags)
-  end
-
-  def ant_dep(tags)
-    Dependency.new("ant", tags)
-  end
-
-  def xz_dep(tags)
-    Dependency.new("xz", tags)
   end
 
   def resource_dep(spec, tags)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

They were already public on macOS, but they were made
private by mistake on all other platforms.
DependencyCollector.tar_needs_xz_dependency? depends
on xz_dep being public, so there's no turning back now :(

This is just a cherry-pick of https://github.com/Homebrew/brew/pull/1588. Closes Linuxbrew/brew#180