### PR TITLE
Fix dynamically_linked_libraries for Linuxbrew

### DIFF
--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -61,7 +61,9 @@ module ELF
   # Returns an empty array both for software that links against no libraries,
   # and for non-ELF objects.
   # @private
-  def dynamically_linked_libraries
+  def dynamically_linked_libraries(except: :none)
+    # The argument except is unused.
+    puts if except == :unused
     metadata.dylibs
   end
 


### PR DESCRIPTION
Fix the `brew linkage` error:
```
Error: wrong number of arguments (1 for 0)
Library/Homebrew/os/linux/elf.rb:64:in `dynamically_linked_libraries'
```