### PR TITLE
TapLoader.get_formula: Fix test-bot for Linuxbrew

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -198,6 +198,7 @@ class Formulary
     end
 
     def get_formula(spec, alias_path: nil)
+      tap.install if !tap.installed? && ARGV.homebrew_developer?
       super
     rescue FormulaUnavailableError => e
       raise TapFormulaUnavailableError.new(tap, name), "", e.backtrace


### PR DESCRIPTION
Install the tap if it's not yet installed.
Fix
```
Error: No available formula with the name "linuxbrew/xorg/xorg"
Please tap it and then try again: brew tap linuxbrew/xorg
```