### PR TITLE
Allow user to specify curl binary

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -88,7 +88,7 @@ case "$HOMEBREW_SYSTEM" in
   Linux)  HOMEBREW_LINUX="1" ;;
 esac
 
-HOMEBREW_CURL="/usr/bin/curl"
+[[ -z "$HOMEBREW_CURL" ]] && HOMEBREW_CURL="/usr/bin/curl"
 if [[ -n "$HOMEBREW_MACOS" ]]
 then
   HOMEBREW_PROCESSOR="$(uname -p)"
@@ -101,7 +101,8 @@ then
 
   printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_VERSION//./ }
   if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "100900" &&
-        -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
+        -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" &&
+        -z "$HOMEBREW_CURL" ]]
   then
     HOMEBREW_CURL="$HOMEBREW_PREFIX/opt/curl/bin/curl"
   fi
@@ -112,7 +113,8 @@ else
   [[ -n "$HOMEBREW_LINUX" ]] && HOMEBREW_OS_VERSION="$(lsb_release -sd 2>/dev/null)"
   : "${HOMEBREW_OS_VERSION:=$(uname -r)}"
 
-  if [[ -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
+  if [[ -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" &&
+      -z "$HOMEBREW_CURL" ]]
   then
     HOMEBREW_CURL="$HOMEBREW_PREFIX/opt/curl/bin/curl"
   fi


### PR DESCRIPTION
If the user wants to use a different version of curl (such as the system
version) for home/linuxbrew operations, set the environment variable `HOMEBREW_CURL`.

There are some systems, particularly those behind proxies where using
the curl binary provided by home/linuxbrew causes problems and using the
system provided curl is preferable.

This overwrites Linuxbrew/brew#48 as that PR is stale.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
