### PR TITLE
uses: Implement HOMEBREW_VERBOSE_USING_DOTS

### DIFF
--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -45,7 +45,16 @@ module Homebrew
     end
     ignores << "recommended?" if ARGV.include? "--skip-recommended"
 
+    verbose_using_dots = !ENV["HOMEBREW_VERBOSE_USING_DOTS"].nil?
+    last_dot = Time.at(0)
+
     uses = formulae.select do |f|
+      # Print a dot every minute.
+      if verbose_using_dots && (Time.now - last_dot) > 60
+        last_dot = Time.now
+        $stderr.print "."
+      end
+
       used_formulae.all? do |ff|
         begin
           if recursive
@@ -92,6 +101,7 @@ module Homebrew
         end
       end
     end
+    $stderr.puts if verbose_using_dots
 
     return if uses.empty?
     puts Formatter.columns(uses.map(&:full_name))

--- a/Library/Homebrew/test/uses_test.rb
+++ b/Library/Homebrew/test/uses_test.rb
@@ -9,8 +9,10 @@ class IntegrationCommandTestUses < IntegrationCommandTestCase
       depends_on "bar"
     EOS
 
-    assert_equal "", cmd("uses", "baz")
-    assert_equal "baz", cmd("uses", "bar")
-    assert_match(/(bar\nbaz|baz\nbar)/, cmd("uses", "--recursive", "foo"))
+    # Unset HOMEBREW_VERBOSE_USING_DOTS, as a dot in the output fails this test.
+    env = { "HOMEBREW_VERBOSE_USING_DOTS" => nil }
+    assert_equal "", cmd("uses", "baz", env)
+    assert_equal "baz", cmd("uses", "bar", env)
+    assert_match(/(bar\nbaz|baz\nbar)/, cmd("uses", "--recursive", "foo", env))
   end
 end


### PR DESCRIPTION
Print a dot every minute when `HOMEBREW_VERBOSE_USING_DOTS` is set.
`brew uses --recursive` can take longer than ten minutes, and Circle CI times out if a command produces no output in ten minutes.