### PR TITLE
extend/ENV/std.rb: Add libxml2 for Linuxbrew

### DIFF
--- a/Library/Homebrew/compat/ENV/std.rb
+++ b/Library/Homebrew/compat/ENV/std.rb
@@ -21,10 +21,6 @@ module Stdenv
     gcc_4_2
   end
 
-  def libxml2
-    odeprecated "ENV.libxml2"
-  end
-
   def libpng
     odeprecated "ENV.libpng", "ENV.x11"
   end

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -218,6 +218,9 @@ module Stdenv
     append "CXX", "-stdlib=libstdc++" if compiler == :clang
   end
 
+  def libxml2
+  end
+
   # @private
   def replace_in_cflags(before, after)
     CC_FLAG_VARS.each do |key|


### PR DESCRIPTION
`ENV.libxml2` is deprecated in superenv used during install,
but defined in stdenv used during test.

See Linuxbrew/brew#219.