### PR TITLE
support c++ for old system

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -132,7 +132,7 @@ module Stdenv
   # @private
   def determine_cxx
     dir, base = determine_cc.split
-    dir / base.to_s.sub("gcc", "g++").sub("clang", "clang++")
+    dir / base.to_s.sub("gcc", "g++").sub("clang", "clang++").sub(/\bcc\b/, "c++")
   end
 
   def gcc_4_0


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
gcc was recognized from 4.3 as [here](https://github.com/Linuxbrew/brew/blob/master/Library/Homebrew/compilers.rb#L3)
my system has gcc-4.1, so `CC` was set to `/usr/bin/cc` instead of `/usr/bin/gcc`
and CXX was set as `dir / base.to_s.sub("gcc", "g++").sub("clang", "clang++")` and not changed.
so I add replace `/\bcc\b/` to `c++` for it
for some c++ project CXXLD is set by CXX
when link c++ program, it will be lack of libstdc++ when use cc as linker