### PR TITLE
Fix tests --generic for Linuxbrew

### DIFF
--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -9,7 +9,6 @@ module OS
     RUBY_PLATFORM.to_s.downcase.include?("linux") || RbConfig::CONFIG["host_os"].downcase.include?("linux")
   end
 
-  require "os/mac"
   ::OS_VERSION = ENV["HOMEBREW_OS_VERSION"]
 
   if OS.mac?
@@ -26,6 +25,7 @@ module OS
     ::MACOS_FULL_VERSION = OS::Mac.full_version.to_s.freeze
     ::MACOS_VERSION = OS::Mac.version.to_s.freeze
   elsif OS.linux?
+    require "os/mac"
     NAME = "linux".freeze
     GITHUB_USER = "Linuxbrew".freeze
     ISSUES_URL = "https://github.com/Linuxbrew/brew/blob/master/docs/Troubleshooting.md#troubleshooting".freeze
@@ -33,5 +33,7 @@ module OS
     PATH_PATCH = "patch".freeze
     # compatibility
     ::MACOS_FULL_VERSION = ::MACOS_VERSION = "0".freeze
+  else
+    PATH_PATCH = "patch".freeze
   end
 end

--- a/Library/Homebrew/test/cleaner_test.rb
+++ b/Library/Homebrew/test/cleaner_test.rb
@@ -22,7 +22,7 @@ class CleanerTests < Homebrew::TestCase
 
     Cleaner.new(@f).clean
 
-    mach_executable_perm = OS.mac? ? 0100555 : 0100444
+    mach_executable_perm = OS.linux? ? 0100444 : 0100555
     assert_equal mach_executable_perm, (@f.bin/"a.out").stat.mode
     assert_equal 0100444, (@f.lib/"fat.dylib").stat.mode
     assert_equal 0100444, (@f.lib/"x86_64.dylib").stat.mode

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -5,7 +5,11 @@ module Utils
   class Bottles
     class << self
       def tag
-        @bottle_tag ||= "#{ENV["HOMEBREW_PROCESSOR"]}_#{ENV["HOMEBREW_SYSTEM"]}".downcase.to_sym
+        @bottle_tag ||= if ENV["HOMEBREW_SYSTEM"] == "Linux"
+          "#{ENV["HOMEBREW_PROCESSOR"]}_#{ENV["HOMEBREW_SYSTEM"]}"
+        else
+          "#{ENV["HOMEBREW_SYSTEM"]}_#{ENV["HOMEBREW_PROCESSOR"]}"
+        end.downcase.to_sym
       end
 
       def built_as?(f)


### PR DESCRIPTION
test_clean_file: Fix tests --generic for Linuxbrew

With --generic, cleaner will never remove the executable bit.
Both Mac and Linux override executable_path?

os.rb: Do not load os/mac.rb with tests --generic

utils/bottles.rb: Fix --generic tag for Linuxbrew

The generic bottle tag on Mac is macintosh_intel and the bottle tag on Linux is x86_64_linux.