### PR TITLE
pull --bottle: Fix publish_bottle_file_on_bintray

### DIFF
--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -423,7 +423,7 @@ module Homebrew
     bintray_project = ARGV.include?("--linux") || f.tap.linux? ? "linuxbrew" : "homebrew"
     repo = Utils::Bottles::Bintray.repository(f.tap)
     package = Utils::Bottles::Bintray.package(f.name)
-    info = FormulaInfoFromJson.lookup(f.name)
+    info = FormulaInfoFromJson.lookup(f.full_name)
     if info.nil?
       raise "Failed publishing bottle: failed reading formula info for #{f.full_name}"
     end


### PR DESCRIPTION
Use formula.full_name rather than formula.name.