### PR TITLE
improve error message for non-sticky HOMEBREW_TEMP

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -292,6 +292,9 @@ module Homebrew
         <<-EOS.undent
           #{HOMEBREW_TEMP} is world-writable but does not have the sticky bit set.
           Please execute `sudo chmod +t #{HOMEBREW_TEMP}` in your Terminal.
+          Alternatively, if you don't have administrative privileges on this
+          machine, point the HOMEBREW_TEMP environment variable to a directory
+          you control, e.g. `mkdir ~/tmp; chmod 755 ~/tmp; export HOMEBREW_TEMP=~/tmp`.
         EOS
       end
 

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -3,44 +3,59 @@ require "socket"
 
 module Utils
   def self.safe_fork(&_block)
-    Dir.mktmpdir("homebrew", HOMEBREW_TEMP) do |tmpdir|
-      UNIXServer.open("#{tmpdir}/socket") do |server|
-        read, write = IO.pipe
+    begin
+      Dir.mktmpdir("homebrew", HOMEBREW_TEMP) do |tmpdir|
+        UNIXServer.open("#{tmpdir}/socket") do |server|
+          read, write = IO.pipe
 
-        pid = fork do
-          begin
-            ENV["HOMEBREW_ERROR_PIPE"] = server.path
-            server.close
-            read.close
-            write.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
-            yield
-          rescue Exception => e
-            Marshal.dump(e, write)
+          pid = fork do
+            begin
+              ENV["HOMEBREW_ERROR_PIPE"] = server.path
+              server.close
+              read.close
+              write.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+              yield
+            rescue Exception => e
+              Marshal.dump(e, write)
+              write.close
+              exit!
+            else
+              exit!(true)
+            end
+          end
+
+          ignore_interrupts(:quietly) do # the child will receive the interrupt and marshal it back
+            begin
+              socket = server.accept_nonblock
+            rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::ECONNABORTED, Errno::EPROTO, Errno::EINTR
+              retry unless Process.waitpid(pid, Process::WNOHANG)
+            else
+              socket.send_io(write)
+              socket.close
+            end
             write.close
-            exit!
-          else
-            exit!(true)
+            data = read.read
+            read.close
+            Process.wait(pid) unless socket.nil?
+            raise Marshal.load(data) unless data.nil? || data.empty?
+            raise Interrupt if $?.exitstatus == 130
+            raise "Suspicious failure" unless $?.success?
           end
-        end
-
-        ignore_interrupts(:quietly) do # the child will receive the interrupt and marshal it back
-          begin
-            socket = server.accept_nonblock
-          rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::ECONNABORTED, Errno::EPROTO, Errno::EINTR
-            retry unless Process.waitpid(pid, Process::WNOHANG)
-          else
-            socket.send_io(write)
-            socket.close
-          end
-          write.close
-          data = read.read
-          read.close
-          Process.wait(pid) unless socket.nil?
-          raise Marshal.load(data) unless data.nil? || data.empty?
-          raise Interrupt if $?.exitstatus == 130
-          raise "Suspicious failure" unless $?.success?
         end
       end
+    rescue ArgumentError => e
+      if e.message == "parent directory is world writable but not sticky"
+        message = <<-EOS.undent
+          #{HOMEBREW_TEMP} is world-writable but does not have the sticky bit set.
+          Please execute `sudo chmod +t #{HOMEBREW_TEMP}` in your Terminal.
+          Alternatively, if you don't have administrative privileges on this
+          machine, point the HOMEBREW_TEMP environment variable to a directory
+          you control, e.g. `mkdir ~/tmp; chmod 755 ~/tmp; export HOMEBREW_TEMP=~/tmp`.
+        EOS
+      else
+        message = e.message
+      end
+      raise e, message, e.backtrace
     end
   end
 end


### PR DESCRIPTION
- show a comprehensive tip on how to resolve the issue both when running `brew doctor` and when an error is raised during a formula build because of this
- see #234 for a discussion of why this is useful
- not quite sure whether this needs tests, and if so, what they should look like
- the error message isn't DRY, it's copy-pasted in two places, but short of yanking it out into a separate module and file (which I felt would be too big an incursion), I don't really see a better solution
- this patch catches the exception as close to its occurrence in the `brew install` execution path as possible (i.e. in `utils/fork.rb`), but there are a few other calls to `Dir.mktmpdir` with `HOMEBREW_TEMP` scattered around the codebase which are therefore not covered
  - hard to tell at a glance (for a novice to the codebase) if these are plausibly reachable by a regular user
  - catching the exception at the topmost level (`brew.rb`) is tempting, but since the codebase also contains calls to `Dir.mktmpdir` without `HOMEBREW_TEMP` (again, I don't know whether these are code paths the typical user will come across), the improved error message (which references `HOMEBREW_TEMP`) might then be actually *more* confusing