### PR TITLE
Hardware::CPU.optimization_flags: Fix for Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -1,6 +1,16 @@
 module Hardware
   class CPU
     class << self
+      OPTIMIZATION_FLAGS_LINUX = {
+        core2: "-march=core2",
+        core: "-march=prescott",
+        dunno: "-march=native",
+      }.freeze
+
+      def optimization_flags
+        OPTIMIZATION_FLAGS_LINUX
+      end
+
       def universal_archs
         [].extend ArchitectureListExtension
       end


### PR DESCRIPTION
Remove penryn and set the default to -march=native.

Two users with penryn systems have reported an illegal instruction error.
It may be related to the -march=core2 -msse4.1 optimization.

Fixes https://github.com/Linuxbrew/homebrew-core/issues/1683