### PR TITLE
Dockerfile: Depend on python-setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:trusty
 MAINTAINER Shaun Jackman <sjackman@gmail.com>
 
 RUN apt-get update \
-	&& apt-get install -y curl g++ git make ruby2.0 ruby2.0-dev uuid-runtime \
+	&& apt-get install -y curl g++ git make python-setuptools ruby2.0 ruby2.0-dev uuid-runtime \
 	&& ln -sf ruby2.0 /usr/bin/ruby \
 	&& ln -sf gem2.0 /usr/bin/gem
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

-----

From https://github.com/Linuxbrew/homebrew-core/pull/1744#issuecomment-279196489 I discovered that python-setuptools isn't contained in the linuxbrew/linuxbrew Docker image.