### PR TITLE
Dockerfile: export USER=linuxbrew

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ RUN chown -R linuxbrew: /home/linuxbrew/.linuxbrew \
 USER linuxbrew
 WORKDIR /home/linuxbrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
-	SHELL=/bin/bash
+	SHELL=/bin/bash \
+	USER=linuxbrew


### PR DESCRIPTION
`brew test rust` failed on the Docker image because the
USER environment variable was unset.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

-----
