### PR TITLE
superenv: Fix tests for Linuxbrew

### DIFF
--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -9,6 +9,9 @@ module Superenv
     binutils = Formula["binutils"]
     paths << binutils.opt_bin if binutils.installed?
     paths
+  rescue FormulaUnavailableError
+    # Fix for brew tests, which uses NullLoader.
+    []
   end
 
   def determine_rpath_paths


### PR DESCRIPTION
Fix `Error: No available formula with the name "binutils"`