### PR TITLE
audit: Skip OS.mac?/OS.linux? check for Linuxbrew

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1101,7 +1101,7 @@ class FormulaAuditor
       problem "'fails_with :llvm' is now a no-op so should be removed"
     end
 
-    if formula.tap.to_s == "homebrew/core" && OS.mac?
+    if formula.tap.to_s == "homebrew/core" && !formula.tap.remote[/linuxbrew/i]
       ["OS.mac?", "OS.linux?"].each do |check|
         next unless line.include?(check)
         problem "Don't use #{check}; Homebrew/core only supports macOS"


### PR DESCRIPTION
Skip `OS.mac?` and `OS.linux?` check so that `brew audit` and `brew build-bottle-pr` work with Linuxbrew on a Mac.