### PR TITLE
Fix update-test --to-tag on macOS for Linuxbrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
       rvm: 2.0.0
 
 before_install:
+  - git fetch --tags --unshallow
   - export HOMEBREW_DEVELOPER=1
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
       HOMEBREW_REPOSITORY="$(brew --repo)";

--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -33,7 +33,7 @@ module Homebrew
     elsif date = ARGV.value("before")
       Utils.popen_read("git", "rev-list", "-n1", "--before=#{date}", "origin/master").chomp
     elsif ARGV.include?("--to-tag")
-      Utils.popen_read("git", "tag", "--list", "--sort=-version:refname").lines[1].chomp
+      Utils.popen_read("git", "tag", "--list", "--sort=-version:refname").lines[1].to_s.chomp
     else
       Utils.popen_read("git", "rev-parse", "origin/master").chomp
     end


### PR DESCRIPTION
Fix `Error: undefined method 'chomp' for nil:NilClass`