### PR TITLE
.travis.yml: Add git fetch --tags for Linuxbrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
       rvm: 2.0.0
 
 before_install:
+  - git fetch --tags --depth=1
   - export HOMEBREW_DEVELOPER=1
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
       HOMEBREW_REPOSITORY="$(brew --repo)";


### PR DESCRIPTION
Add `git fetch --tags --depth=1`.
Prevent `git tag --list --sort=-version:refname` from failing
to fix `brew test-update --to-tag`.