### PR TITLE
Skip verification of SSL certificates

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -24,6 +24,7 @@ def curl_args(options = {})
     args << "--progress-bar" unless ARGV.verbose?
     args << "--verbose" if ENV["HOMEBREW_CURL_VERBOSE"]
     args << "--fail"
+		args << "--insecure"
     args << "--silent" if !$stdout.tty? || ENV["TRAVIS"]
   end
 


### PR DESCRIPTION
cURL will frequently fail to download files, particularly over TLS, due to certificates being missing on users' systems. This will work around that common issue and prevent users from needing to work around it as is directed in the wiki (https://github.com/Linuxbrew/brew/wiki/FAQ).
Maybe, for security's sake, optional OpenPGP signature verification can be done for downloads in the future for those who demonstrate need for the security. In the meantime, this will work around the issue.