### PR TITLE
circle.yml: Remove git fetch --tags

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,6 @@ machine:
 checkout:
   post:
     - if [ -e .git/shallow ]; then echo git fetch --unshallow; fi
-    - git fetch --tags
     - git config user.name LinuxbrewTestBot
     - git config user.email testbot@linuxbrew.sh
 test:


### PR DESCRIPTION
It is redundant with git fetch --unshallow.