### PR TITLE
lock with FD 99 instead of 200 for systems with low ulimit -n (#314)

### DIFF
--- a/Library/Homebrew/utils/lock.sh
+++ b/Library/Homebrew/utils/lock.sh
@@ -14,7 +14,7 @@ Fix permissions by running:
   sudo chown -R \$(whoami) $HOMEBREW_PREFIX/var/homebrew
 EOS
   fi
-  # 200 is the file descriptor used in the lock.
+  # 99 is the file descriptor used in the lock.
   # This FD should be used exclusively for lock purpose.
   # Any value except 0(stdin), 1(stdout) and 2(stderr) can do the job.
   # Noted, FD is unique per process but it will be shared to subprocess.
@@ -22,10 +22,10 @@ EOS
   # other FD opened by the script.
   #
   # close FD first, this is required if parent process holds a different lock.
-  exec 200>&-
+  exec 99>&-
   # open the lock file to FD, so the shell process can hold the lock.
-  exec 200>"$lock_file"
-  if ! _create_lock 200 "$name"
+  exec 99>"$lock_file"
+  if ! _create_lock 99 "$name"
   then
     odie <<EOS
 Another active Homebrew $name process is already in progress.


### PR DESCRIPTION
Make `brew` work on systems with a `ulimit -n` of 100.
Lock with FD 99 instead of 200 for systems with low `ulimit -n`.
Fixes Linuxbrew/brew#314