### PR TITLE
superenv: fix calls to -R

### DIFF
--- a/Library/Homebrew/shims/linux/super/cc
+++ b/Library/Homebrew/shims/linux/super/cc
@@ -184,6 +184,11 @@ class Cmd
       val  = chuzzle($1) || enum.next
       path = canonical_path(val)
       args << "-L#{val}" if keep?(path) && @lset.add?(path)
+    when /^-R(.+)?/
+      # -R is not the correct way to pass rpaths to the linker
+      val  = chuzzle($1) || enum.next
+      path = canonical_path(val)
+      args << "-Wl,-R," if keep?(path) && @lset.add?(path)
     else
       args << arg
     end

--- a/Library/Homebrew/shims/linux/super/cc
+++ b/Library/Homebrew/shims/linux/super/cc
@@ -187,8 +187,8 @@ class Cmd
     when /^-R(.+)?/
       # -R is not the correct way to pass rpaths to the linker
       val  = chuzzle($1) || enum.next
-      path = canonical_path(val)
-      args << "-Wl,-rpath=" if keep?(path) && @lset.add?(path)
+      wl = "-Wl," unless mode == :ld
+      args << "-Wl,-rpath=" if keep?(path)
     else
       args << arg
     end

--- a/Library/Homebrew/shims/linux/super/cc
+++ b/Library/Homebrew/shims/linux/super/cc
@@ -188,7 +188,7 @@ class Cmd
       # -R is not the correct way to pass rpaths to the linker
       val  = chuzzle($1) || enum.next
       path = canonical_path(val)
-      args << "-Wl,-R," if keep?(path) && @lset.add?(path)
+      args << "-Wl,-rpath=" if keep?(path) && @lset.add?(path)
     else
       args << arg
     end

--- a/Library/Homebrew/shims/linux/super/cc
+++ b/Library/Homebrew/shims/linux/super/cc
@@ -188,7 +188,7 @@ class Cmd
       # -R is not the correct way to pass rpaths to the linker
       val  = chuzzle($1) || enum.next
       wl = "-Wl," unless mode == :ld
-      args << "-Wl,-rpath=" if keep?(path)
+      args << "#{wl}-rpath=" if keep?(path)
     else
       args << arg
     end


### PR DESCRIPTION
`cc -R` is not the right way to pass rpaths to the linker. This pull request fixes that by modifying superenv. 

This might fix on Linux these issues: 

https://github.com/Homebrew/homebrew-science/pull/5065
https://github.com/h5py/h5py/issues/845
