### PR TITLE
linkage: Fail --test if host deps for Linuxbrew

### DIFF
--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -22,6 +22,11 @@ module Homebrew
       if ARGV.include?("--test")
         result.display_test_output
         Homebrew.failed = true if result.broken_dylibs?
+        if OS.linux?
+          host_whitelist = %w[libc.so.6 libm.so.6 libgcc_s.so.1 libstdc++.so.6]
+          host_deps = result.system_dylibs.to_a.map { |s| File.basename s }
+          Homebrew.failed = true unless (host_deps - host_whitelist).empty?
+        end
       elsif ARGV.include?("--reverse")
         result.display_reverse_output
       else

--- a/Library/Homebrew/os/mac/linkage_checker.rb
+++ b/Library/Homebrew/os/mac/linkage_checker.rb
@@ -102,6 +102,7 @@ class LinkageChecker
   end
 
   def display_test_output
+    display_items "System libraries", @system_dylibs if OS.linux?
     display_items "Missing libraries", @broken_dylibs
     puts "No broken dylib links" if @broken_dylibs.empty?
   end


### PR DESCRIPTION
Fail if the keg has either broken dylibs or host dependencies.
