### PR TITLE
ENV.x11: Fix for Linuxbrew superenv

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -83,7 +83,8 @@ class Build
       ENV.keg_only_deps = keg_only_deps
       ENV.deps = formula_deps
       ENV.run_time_deps = run_time_deps
-      ENV.x11 = reqs.any? { |rq| rq.is_a?(X11Requirement) }
+      ENV.x11 = reqs.any? { |rq| rq.is_a?(X11Requirement) } ||
+                deps.any? { |dep| dep.name == "linuxbrew/xorg/xorg" }
       ENV.setup_build_environment(formula)
       post_superenv_hacks
       reqs.each(&:modify_build_environment)

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -1,13 +1,23 @@
 module Superenv
+  alias x11? x11
+
   # @private
   def self.bin
     (HOMEBREW_SHIMS_PATH/"linux/super").realpath
+  end
+
+  def xorg_recursive_deps
+    return [] unless xorg_installed?
+    @xorg_deps ||= Formula["linuxbrew/xorg/xorg"].recursive_dependencies.map(&:to_formula)
+  rescue FormulaUnavailableError
+    []
   end
 
   def homebrew_extra_paths
     paths = []
     binutils = Formula["binutils"]
     paths << binutils.opt_bin if binutils.installed?
+    paths += xorg_recursive_deps.map(&:opt_bin) if x11?
     paths
   rescue FormulaUnavailableError
     # Fix for brew tests, which uses NullLoader.
@@ -27,5 +37,74 @@ module Superenv
     else
       "#{HOMEBREW_PREFIX}/lib/ld.so"
     end
+  end
+
+  # @private
+  def homebrew_extra_pkg_config_paths
+    paths = []
+    if x11?
+      libs = xorg_recursive_deps.map(&:lib)
+      shares = xorg_recursive_deps.map(&:share)
+      libs.each do |lib|
+        paths << lib/"pkgconfig"
+      end
+      shares.each do |share|
+        paths << share/"pkgconfig"
+      end
+    end
+    paths
+  end
+
+  def homebrew_extra_aclocal_paths
+    paths = []
+    if x11?
+      shares = xorg_recursive_deps.map(&:share)
+      shares.each do |share|
+        paths << share/"aclocal"
+      end
+    end
+    paths
+  end
+
+  def xorg_include_paths
+    xorg_recursive_deps.map(&:include)
+  end
+
+  def xorg_lib_paths
+    xorg_recursive_deps.map(&:lib)
+  end
+
+  def homebrew_extra_isystem_paths
+    paths = []
+    paths += xorg_include_paths if x11?
+    paths
+  end
+
+  def homebrew_extra_library_paths
+    paths = []
+    paths += xorg_lib_paths if x11?
+    paths
+  end
+
+  def homebrew_extra_cmake_include_paths
+    paths = []
+    paths += xorg_include_paths if x11?
+    paths
+  end
+
+  def homebrew_extra_cmake_library_paths
+    paths = []
+    paths += xorg_lib_paths if x11?
+    paths
+  end
+
+  def set_x11_env_if_installed
+    ENV.x11 = xorg_installed?
+  end
+
+  def xorg_installed?
+    Formula["linuxbrew/xorg/xorg"].installed?
+  rescue FormulaUnavailableError
+    false
   end
 end

--- a/Library/Homebrew/requirements/xorg_requirement.rb
+++ b/Library/Homebrew/requirements/xorg_requirement.rb
@@ -4,6 +4,8 @@ class XorgRequirement < Requirement
   fatal true
   default_formula "linuxbrew/xorg/xorg"
 
+  env { ENV.x11 }
+
   def initialize(name = "xorg", tags = [])
     @name = name
     tags.shift if tags.first =~ /(\d\.)+\d/


### PR DESCRIPTION
Three things need to be done:

1. Trigger ENV.X11 for both XorgRequirement and X11Requirement
2. Implement ENV.X11 for Linux superenv
3. Inform the XorgRequirement of this

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
