### PR TITLE
linkage: whitelist host dynamic linker (ld-linux)

### DIFF
--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -24,6 +24,7 @@ module Homebrew
         Homebrew.failed = true if result.broken_dylibs?
         if OS.linux?
           host_whitelist = %w[
+            ld-linux-x86-64.so.2
             libc.so.6
             libcrypt.so.1
             libdl.so.2


### PR DESCRIPTION
This only covers the amd64 case, but better that than nothing

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I hope this will fix the `brew linkage` failure on Circle for https://github.com/Linuxbrew/homebrew-core/pull/2347