### PR TITLE
linkage: display unwanted host libraries for Linuxbrew

### DIFF
--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -23,23 +23,7 @@ module Homebrew
         result.display_test_output
         Homebrew.failed = true if result.broken_dylibs?
         if OS.linux?
-          host_whitelist = %w[
-            ld-linux-x86-64.so.2
-            libc.so.6
-            libcrypt.so.1
-            libdl.so.2
-            libm.so.6
-            libnsl.so.1
-            libpthread.so.0
-            librt.so.1
-            libutil.so.1
-
-            libgcc_s.so.1
-            libgomp.so.1
-            libstdc++.so.6
-          ]
-          host_deps = result.system_dylibs.to_a.map { |s| File.basename s }
-          Homebrew.failed = true unless (host_deps - host_whitelist).empty?
+          Homebrew.failed = true if result.unwanted_system_dylibs?
         end
       elsif ARGV.include?("--reverse")
         result.display_reverse_output


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is intended to display the non-whitelisted host libraries in use by a given formula. It's easier to tell that `brew linkage --test` failed and why; before the only indication was that the exit status was 1.

I alluded to this in #342 