### PR TITLE
superenv: add HOMEBREW_DYNAMIC_LINKER

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -63,6 +63,7 @@ module Superenv
     self["HOMEBREW_INCLUDE_PATHS"] = determine_include_paths
     self["HOMEBREW_LIBRARY_PATHS"] = determine_library_paths
     self["HOMEBREW_RPATH_PATHS"] = determine_rpath_paths
+    self["HOMEBREW_DYNAMIC_LINKER"] = determine_dynamic_linker_path(formula)
     self["HOMEBREW_DEPENDENCIES"] = determine_dependencies
     self["HOMEBREW_FORMULA_PREFIX"] = formula.prefix unless formula.nil?
 
@@ -184,6 +185,10 @@ module Superenv
   end
 
   def determine_rpath_paths
+    ""
+  end
+
+  def determine_dynamic_linker_path(_formula)
     ""
   end
 

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -20,4 +20,12 @@ module Superenv
     paths += homebrew_extra_library_paths
     paths.to_path_s
   end
+
+  def determine_dynamic_linker_path(formula)
+    if formula && formula.name == "glibc"
+      ""
+    else
+      "#{HOMEBREW_PREFIX}/lib/ld.so"
+    end
+  end
 end

--- a/Library/Homebrew/shims/linux/super/cc
+++ b/Library/Homebrew/shims/linux/super/cc
@@ -242,7 +242,8 @@ class Cmd
 
   def ldflags
     wl = "-Wl," unless mode == :ld
-    args = ["#{wl}--dynamic-linker=#{prefix}/lib/ld.so"]
+    args = []
+    args += ["#{wl}--dynamic-linker=#{dynamic_linker_path}"] if dynamic_linker_path
     args += path_flags("-L", library_paths)
     args += path_flags("#{wl}-rpath=", rpath_paths)
   end
@@ -261,6 +262,10 @@ class Cmd
 
   def rpath_paths
     path_split("HOMEBREW_RPATH_PATHS")
+  end
+
+  def dynamic_linker_path
+    chuzzle(ENV["HOMEBREW_DYNAMIC_LINKER"])
   end
 
   def configure?


### PR DESCRIPTION
This env is used to set the dynamic linker in superenv. By introducing
it, we can:
* avoid stdenv for building glibc
* allow overwriting the dynamic linker for formulae in
  homebrew/homebrew-portable.
