### PR TITLE
Hardware::CPU.type: check uname -m

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -20,9 +20,10 @@ module Hardware
       end
 
       def type
-        @type ||= if cpuinfo =~ /Intel|AMD/
+        @type ||= case Utils.popen_read("uname", "-m").chomp
+        when "x86_64", "amd64", /^i\d86$/
           :intel
-        elsif cpuinfo =~ /ARM|Marvell/
+        when /^arm/
           :arm
         else
           :dunno


### PR DESCRIPTION
Determining CPU type by reading `/proc/cpuinfo` is less reliable than
checking the value of `uname -m`. Particularly, `/proc/cpuinfo` often
return the CPU info for the host CPU when running Linuxbrew inside a VM.
Therefore, if the host and VM share different CPU architectures,
`/proc/cpuinfo` will return incorrect result.

To fix the problem, checking `uname -m` first, otherwise fallback to
`/proc/cpuinfo`.

Fixes #336.

