### PR TITLE
super/cc: Remove -lintl for Linuxbrew

### DIFF
--- a/Library/Homebrew/shims/linux/super/cc
+++ b/Library/Homebrew/shims/linux/super/cc
@@ -150,6 +150,8 @@ class Cmd
       /^-O[0-9zs]?$/, "-fast", "-no-cpp-precomp",
       "-pedantic", "-pedantic-errors", "-Wno-long-double",
       "-Wno-unused-but-set-variable"
+    when "-lintl"
+      # Not needed on Linux.
     when "-fopenmp", "-lgomp", "-mno-fused-madd", "-fforce-addr", "-fno-defer-pop",
       "-mno-dynamic-no-pic", "-fearly-inlining", /^-f(?:no-)?inline-functions-called-once/,
       /^-finline-limit/, /^-f(?:no-)?check-new/, "-fno-delete-null-pointer-checks",


### PR DESCRIPTION
-lintl is not needed on Linux.