### PR TITLE
 shims/super/cc: add HOMEBREW_PREFIX/bin to compiler search path.

### DIFF
--- a/Library/Homebrew/shims/linux/super/cc
+++ b/Library/Homebrew/shims/linux/super/cc
@@ -359,6 +359,7 @@ if __FILE__ == $PROGRAM_NAME
     path = Pathname.new(x)
     path.directory? && path.realpath == superbin
   end
+  paths << "#{ENV["HOMEBREW_PREFIX"]}/bin"
   ENV["PATH"] = paths.join(":")
   args << { :close_others => false }
   exec tool, *args


### PR DESCRIPTION
This helps to locate compilers in one of following cases:
 * From gcc formula.
 * Symlink HOMEBREW_PREFIX/bin/gcc-{ver}