### PR TITLE
stdenv: Add dummy x11 method

### DIFF
--- a/Library/Homebrew/extend/os/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/extend/ENV/std.rb
@@ -1,2 +1,3 @@
 require "extend/ENV/std"
 require "extend/os/mac/extend/ENV/std" if OS.mac?
+require "extend/os/linux/extend/ENV/std" if OS.linux?

--- a/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
@@ -1,0 +1,4 @@
+module Stdenv
+  # needed by XorgRequirement
+  def x11; end
+end


### PR DESCRIPTION
The XorgRequirement needs ENV.x11, so add a dummy one under stdenv
because the normal stdenv logic is sufficient.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes the error @maxim-belkin mentioned for `pango` on #337 