### PR TITLE
change_rpath: Ignore cannot find section .dynstr for Linuxbrew

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -20,9 +20,10 @@ class Keg
       return
     end
 
-    cmd_rpath = [patchelf, "--print-rpath", file]
+    cmd_rpath = "#{patchelf} --print-rpath '#{file}' 2>&1"
     old_rpath = Utils.popen_read(*cmd_rpath).strip
-    raise ErrorDuringExecution, cmd_rpath unless $?.success?
+    return if old_rpath == "cannot find section .dynstr"
+    raise ErrorDuringExecution, "#{cmd_rpath}\n#{old_rpath}" unless $?.success?
     rpath = old_rpath.split(":").map { |x| x.sub(old_prefix, new_prefix) }.select do |x|
       x.start_with?(new_prefix, "$ORIGIN")
     end

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -41,7 +41,7 @@ class Keg
     end
 
     cmd << file
-    if old_rpath == "#{new_prefix}/lib" && old_interpreter == new_interpreter
+    if old_rpath == new_rpath && old_interpreter == new_interpreter
       puts "Skipping relocation of #{file}" if ARGV.debug?
     else
       puts "Setting RPATH of #{file}" if ARGV.debug?

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -1,6 +1,8 @@
 class Keg
   def relocate_dynamic_linkage(relocation)
     return if name == "glibc"
+    # Patching patchelf using itself fails with "Text file busy" or SIGBUS.
+    return if name == "patchelf"
     elf_files.each do |file|
       file.ensure_writable do
         change_rpath(file, relocation.old_prefix, relocation.new_prefix)
@@ -11,35 +13,36 @@ class Keg
   def change_rpath(file, old_prefix, new_prefix)
     return unless file.elf? && file.dynamic?
 
-    # Patching patchelf using itself fails with "Text file busy" or SIGBUS.
-    return if name == "patchelf"
-
     begin
-      patchelf = Formula["patchelf"]
+      patchelf = Formula["patchelf"].bin/"patchelf"
     rescue FormulaUnavailableError
       # Fix for brew tests, which uses NullLoader.
       return
     end
-    return unless patchelf.installed?
-    cmd = "#{patchelf.bin}/patchelf --set-rpath #{new_prefix}/lib"
-    old_rpath = `#{patchelf.bin}/patchelf --print-rpath #{file}`.strip
-    raise ErrorDuringExecution, cmd unless $?.success?
-    lib_path = "#{new_prefix}/lib"
+
+    cmd_rpath = [patchelf, "--print-rpath", file]
+    old_rpath = Utils.popen_read(*cmd_rpath).strip
+    raise ErrorDuringExecution, cmd_rpath unless $?.success?
     rpath = old_rpath.split(":").map { |x| x.sub(old_prefix, new_prefix) }.select do |x|
       x.start_with?(new_prefix, "$ORIGIN")
     end
+
+    lib_path = "#{new_prefix}/lib"
     rpath << lib_path unless rpath.include? lib_path
     new_rpath = rpath.join(":")
-    cmd = ["#{patchelf.bin}/patchelf", "--set-rpath", new_rpath]
+    cmd = [patchelf, "--set-rpath", new_rpath]
+
     if file.mach_o_executable?
-      old_interpreter = `#{patchelf.bin}/patchelf --print-interpreter #{file}`.strip
-      raise ErrorDuringExecution, cmd unless $?.success?
-      interpreter = new_prefix == PREFIX_PLACEHOLDER ? "/lib64/ld-linux-x86-64.so.2" : "#{HOMEBREW_PREFIX}/lib/ld.so"
-      cmd << "--set-interpreter" << interpreter unless old_interpreter == interpreter
+      cmd_interpreter = [patchelf, "--print-interpreter", file]
+      old_interpreter = Utils.popen_read(*cmd_interpreter).strip
+      raise ErrorDuringExecution, cmd_interpreter unless $?.success?
+      new_interpreter = new_prefix == PREFIX_PLACEHOLDER ? "/lib64/ld-linux-x86-64.so.2" : "#{HOMEBREW_PREFIX}/lib/ld.so"
+      cmd << "--set-interpreter" << new_interpreter unless old_interpreter == new_interpreter
     end
+
     cmd << file
-    if old_rpath == "#{new_prefix}/lib" && old_interpreter == interpreter
-      puts "Skipping relocation of #{file} (RPATH already set)" if ARGV.debug?
+    if old_rpath == "#{new_prefix}/lib" && old_interpreter == new_interpreter
+      puts "Skipping relocation of #{file}" if ARGV.debug?
     else
       puts "Setting RPATH of #{file}" if ARGV.debug?
       safe_system(*cmd)

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -41,13 +41,8 @@ class Keg
       cmd << "--set-interpreter" << new_interpreter unless old_interpreter == new_interpreter
     end
 
-    cmd << file
-    if old_rpath == new_rpath && old_interpreter == new_interpreter
-      puts "Skipping relocation of #{file}" if ARGV.debug?
-    else
-      puts "Setting RPATH of #{file}" if ARGV.debug?
-      safe_system(*cmd)
-    end
+    return if old_rpath == new_rpath && old_interpreter == new_interpreter
+    safe_system(*cmd, file)
   end
 
   # Detects the C++ dynamic libraries in place, scanning the dynamic links


### PR DESCRIPTION
Ignore the patchelf error: cannot find section .dynstr
This error affects Go and Guile exectuables.