### PR TITLE
ruby_requirement: Fix new_enough_ruby

### DIFF
--- a/Library/Homebrew/requirements/ruby_requirement.rb
+++ b/Library/Homebrew/requirements/ruby_requirement.rb
@@ -39,6 +39,7 @@ class RubyRequirement < Requirement
       next unless new_enough?(ruby)
       rubyhdrdir = Pathname.new Utils.popen_read(ruby, "-rrbconfig", "-e", "print RbConfig::CONFIG['rubyhdrdir']")
       next unless (rubyhdrdir/"ruby.h").readable?
+      ruby
     end
   end
 


### PR DESCRIPTION
new_enough_ruby was not returning anything from its detect block.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Test Case to demonstrate this problem: 

1. `brew install ruby` if not already done
2. `brew info libprelude` should show the ruby requirement as satisfied, but it does not.

If you do a `brew irb` run, you see:

```
==> Interactive Homebrew Shell
Example commands available with: brew irb --examples
irb(main):001:0> RubyRequirement.new(["2.4.0"])
=> #<RubyRequirement: "ruby" [] version="2.4.0">
irb(main):002:0> RubyRequirement.new(["2.4.0"]).send(:new_enough_ruby)
=> nil
irb(main):003:0>
```