### PR TITLE
elf_soname_needed_readelf: Fix international for Linuxbrew

### DIFF
--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -78,9 +78,9 @@ module ELF
       lines.each do |s|
         case s
         when /\(SONAME\)/
-          soname = s[/Library soname: \[(.*)\]/, 1]
+          soname = s[/: \[(.*)\]/, 1]
         when /\(NEEDED\)/
-          needed << s[/Shared library: \[(.*)\]/, 1]
+          needed << s[/: \[(.*)\]/, 1]
         end
       end
       [soname, needed]


### PR DESCRIPTION
Fix the regex to handle non-English languages.
(NEEDED) Shared library [libc.so.6]
(NEEDED) Gemeinsame Bibliothek [libc.so.6]
(NEEDED) Bibliothèque partagée: [libc.so.6]

Fixes Linuxbrew/brew#368.