### PR TITLE
BottleLoader: Fix installing a bottle from an URL

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -108,7 +108,7 @@ module Formulary
       case bottle_name
       when %r{(https?|ftp|file)://}
         # The name of the formula is found between the last slash and the last hyphen.
-        resource = Resource.new bottle_name[%r{([^/]+)-}, 1] { url bottle_name }
+        resource = Resource.new File.basename(bottle_name)[/(.+)-/, 1] { url bottle_name }
         downloader = CurlBottleDownloadStrategy.new resource.name, resource
         @bottle_filename = downloader.cached_location
         cached = @bottle_filename.exist?


### PR DESCRIPTION
The name of the formula is not extracted correctly when the URL includes a hyphen.