### PR TITLE
python_requirement: Check for development headers

### DIFF
--- a/Library/Homebrew/requirements/python_requirement.rb
+++ b/Library/Homebrew/requirements/python_requirement.rb
@@ -38,13 +38,13 @@ class PythonRequirement < Requirement
     python = which python_binary
     return unless python
     python_executable = Pathname.new Utils.popen_read(python, "-c", "import sys; print(sys.executable)").strip
-    return python_executable if OS.mac? or devel_installed? python_executable
+    return python_executable if OS.mac? || devel_installed?(python_executable)
   end
 
   def devel_installed?(python_executable)
     short_version = Language::Python.major_minor_version python_executable
     python_prefix = Pathname.new Utils.popen_read(python_executable, "-c", "import sys; print(sys.#{sys_prefix_name})").strip
-    return (python_prefix/"include/python#{short_version}/Python.h").readable?
+    (python_prefix/"include/python#{short_version}#{include_suffix}/Python.h").readable?
   end
 
   def system_python
@@ -63,6 +63,10 @@ class PythonRequirement < Requirement
     "prefix"
   end
 
+  def include_suffix
+    ""
+  end
+
   # Deprecated
   alias to_s python_binary
 end
@@ -79,5 +83,9 @@ class Python3Requirement < PythonRequirement
 
   def sys_prefix_name
     "base_prefix"
+  end
+
+  def include_suffix
+    "m"
   end
 end

--- a/Library/Homebrew/requirements/python_requirement.rb
+++ b/Library/Homebrew/requirements/python_requirement.rb
@@ -35,21 +35,13 @@ class PythonRequirement < Requirement
     return unless python
     python_executable = Pathname.new Utils.popen_read(python, "-c", "import sys; print(sys.executable)").strip
     return python_executable if OS.mac?
+    return devel_installed? python_executable
+  end
 
+  def devel_installed?(python_executable)
     short_version = Language::Python.major_minor_version python_executable
-    python_config = Pathname.new python_executable/"../python#{short_version}-config"
-    return unless python_config.executable?
-
-    python_prefix = Pathname.new Utils.popen_read(python_config, "--prefix").strip
-    return unless (python_prefix/"include/python#{short_version}/Python.h").readable?
-
-    # some versions of python-config don't include a --configdir option,
-    # so have to do two checks for libpython
-    libpython = "libpython#{short_version}.so"
-    python_configdir = Utils.popen_read(python_config, "--configdir")
-    return python_executable if $?.zero? && (Pathname.new(python_configdir.strip)/libpython).readable?
-    exec_prefix = Pathname.new Utils.popen_read(python_config, "--exec-prefix").strip
-    return python_executable if (exec_prefix/"lib/"/libpython).readable?
+    python_prefix = Pathname.new Utils.popen_read(python_executable, "-c", "import sys; print(sys.#{sys_prefix_name}").strip
+    return (python_prefix/"include/python#{short_version}/Python.h").readable?
   end
 
   def system_python
@@ -64,6 +56,10 @@ class PythonRequirement < Requirement
     "python"
   end
 
+  def sys_prefix_name
+    "prefix"
+  end
+
   # Deprecated
   alias to_s python_binary
 end
@@ -76,5 +72,9 @@ class Python3Requirement < PythonRequirement
 
   def python_binary
     "python3"
+  end
+
+  def sys_prefix_name
+    "base_prefix"
   end
 end

--- a/Library/Homebrew/requirements/python_requirement.rb
+++ b/Library/Homebrew/requirements/python_requirement.rb
@@ -31,16 +31,19 @@ class PythonRequirement < Requirement
   end
 
   def which_python
+    @python_executable ||= find_python
+  end
+
+  def find_python
     python = which python_binary
     return unless python
     python_executable = Pathname.new Utils.popen_read(python, "-c", "import sys; print(sys.executable)").strip
-    return python_executable if OS.mac?
-    return devel_installed? python_executable
+    return python_executable if OS.mac? or devel_installed? python_executable
   end
 
   def devel_installed?(python_executable)
     short_version = Language::Python.major_minor_version python_executable
-    python_prefix = Pathname.new Utils.popen_read(python_executable, "-c", "import sys; print(sys.#{sys_prefix_name}").strip
+    python_prefix = Pathname.new Utils.popen_read(python_executable, "-c", "import sys; print(sys.#{sys_prefix_name})").strip
     return (python_prefix/"include/python#{short_version}/Python.h").readable?
   end
 


### PR DESCRIPTION
Note that the mere presence of \<include\>/python2.7 is not enough
to prove the Python headers are installed and that there are at
least two different versions of python-config slithering around,
one of which (Debian's?) has a --configdir option and one of which
does not.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The idea here is to require use of a brewed Python if the system Python lacks either the shared library or the development headers.

This is an early draft; a couple of things I should note:

* I'm not 100% sure my logic is right; my knowledge of Python configuration is far from perfect.
* I have yet to test this with Python 3
* I have only tested this on Ubuntu 17.04. I'll want to test it on at least Debian and CentOS before merging.
* I have not run `brew tests`; I'll worry about that later

I'm doing this on Linuxbrew first so we can iron out the kinks here; that will make porting to upstream easier IMO.