### PR TITLE
brew audit --strict broken with ruby without rubygems

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -180,6 +180,7 @@ module Homebrew
   end
 
   def install_gem_setup_path!(name, version = nil, executable = name)
+    require "rubygems" unless OS.mac?
     # Respect user's preferences for where gems should be installed.
     ENV["GEM_HOME"] = ENV["GEM_OLD_HOME"].to_s
     ENV["GEM_HOME"] = Gem.user_dir if ENV["GEM_HOME"].empty?


### PR DESCRIPTION
So, if your (system) ruby is compiled with [--disable-rubygems](https://github.com/pld-linux/ruby/blob/auto/th/ruby-2.1.10-2/ruby.spec#L480), then ruby interpreter does not automatically `require 'rubygems'`, apps need to do that themselves.

```
[/home/linuxbrew/.linuxbrew/Homebrew (stable)★] ➔ brew audit --strict
Error: uninitialized constant Homebrew::Gem
Please report this bug:
  https://github.com/Linuxbrew/brew/blob/master/docs/Troubleshooting.md#troubleshooting
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils.rb:185:in `install_gem_setup_path!'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cmd/style.rb:69:in `check_style_impl'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cmd/style.rb:63:in `check_style_json'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:95:in `audit'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:100:in `<main>'
```

after patching:
```
[/home/linuxbrew/.linuxbrew/Homebrew (stable)★] ➔ brew audit --strict
==> Installing or updating 'rubocop' gem
Fetching: parser-2.4.0.0.gem (100%)
Successfully installed parser-2.4.0.0
Fetching: parallel-1.11.2.gem (100%)
Successfully installed parallel-1.11.2
Fetching: rubocop-0.49.1.gem (100%)
Successfully installed rubocop-0.49.1
3 gems installed
...
````