### PR TITLE
make brew home open linuxbrew

### DIFF
--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -17,7 +17,7 @@ ARGV.extend(HomebrewArgvExtension)
 
 HOMEBREW_PRODUCT = ENV["HOMEBREW_PRODUCT"]
 HOMEBREW_VERSION = ENV["HOMEBREW_VERSION"]
-HOMEBREW_WWW = "https://brew.sh".freeze
+HOMEBREW_WWW = "http://linuxbrew.sh".freeze
 
 HOMEBREW_DEFAULT_PREFIX = (OS.linux? ? "/home/linuxbrew/.linuxbrew" : "/usr/local").freeze
 


### PR DESCRIPTION
altho the [command](https://github.com/Linuxbrew/brew/blob/1.2.2/Library/Homebrew/cmd/home.rb) seems useless, but decided to fix it :)

i used `http://` url as no valid cert exists on https://linuxbrew.sh