### PR TITLE
README.md: Note required Git version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Dependencies
 * **Ruby** 1.8.6 or newer
 + **GCC** 4.4 or newer
 + **Linux** 2.6.16 or newer
++ **Git** 1.8.5 or newer
 + **64-bit x86** or **32-bit ARM** (Raspberry Pi)
 
 Paste at a Terminal prompt:


### PR DESCRIPTION
Old versions of CentOS/RHEL and similar seem to include
Git 1.7.1, which isn't sufficient to run Linuxbrew.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
