### PR TITLE
WIP: Fix superenv for x86_64-linux-gnu directory

### DIFF
--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -52,6 +52,7 @@ module Superenv
         paths << share/"pkgconfig"
       end
     end
+    paths += deps.map { |d| d.opt_lib/"x86_64-linux-gnu/pkgconfig" }
     paths
   end
 
@@ -83,6 +84,7 @@ module Superenv
   def homebrew_extra_library_paths
     paths = []
     paths += xorg_lib_paths if x11?
+    paths += deps.map { |d| d.opt_lib/"x86_64-linux-gnu" }
     paths
   end
 


### PR DESCRIPTION
Formulae that install stuff into lib/"x86_64-linux-gnu"
won't get picked up by pkg-config in superenv.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?