### PR TITLE
ENV: Add formula.lib to RPATH for unlinked kegs

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -57,15 +57,20 @@ module Stdenv
         # See https://github.com/Linuxbrew/linuxbrew/issues/841
         prepend_path "LD_LIBRARY_PATH", formula.opt_lib
         prepend_create_path "LD_LIBRARY_PATH", formula.prefix
-        prepend "LD_LIBRARY_PATH", formula.lib, File::PATH_SEPARATOR
+        prepend_path "LD_LIBRARY_PATH", formula.lib
       end
 
       # Set the search path for header files.
       prepend_path "CPATH", HOMEBREW_PREFIX/"include"
       # Set the dynamic linker and library search path.
-      append "LDFLAGS", "-Wl,--dynamic-linker=#{HOMEBREW_PREFIX}/lib/ld.so -Wl,-rpath,#{HOMEBREW_PREFIX}/lib"
       prepend_path "LIBRARY_PATH", HOMEBREW_PREFIX/"lib"
+      prepend "LDFLAGS", "-Wl,-rpath=#{HOMEBREW_PREFIX}/lib"
       prepend_path "LD_RUN_PATH", HOMEBREW_PREFIX/"lib"
+      unless formula.nil?
+        prepend "LDFLAGS", "-Wl,-rpath=#{formula.lib}"
+        prepend_path "LD_RUN_PATH", formula.lib
+      end
+      prepend "LDFLAGS", "-Wl,--dynamic-linker=#{HOMEBREW_PREFIX}/lib/ld.so"
     end
 
     if inherit?

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -62,7 +62,7 @@ module Superenv
     self["HOMEBREW_ISYSTEM_PATHS"] = determine_isystem_paths
     self["HOMEBREW_INCLUDE_PATHS"] = determine_include_paths
     self["HOMEBREW_LIBRARY_PATHS"] = determine_library_paths
-    self["HOMEBREW_RPATH_PATHS"] = determine_rpath_paths
+    self["HOMEBREW_RPATH_PATHS"] = determine_rpath_paths(formula)
     self["HOMEBREW_DYNAMIC_LINKER"] = determine_dynamic_linker_path(formula)
     self["HOMEBREW_DEPENDENCIES"] = determine_dependencies
     self["HOMEBREW_FORMULA_PREFIX"] = formula.prefix unless formula.nil?
@@ -189,8 +189,11 @@ module Superenv
     []
   end
 
-  def determine_rpath_paths
-    PATH.new(determine_extra_rpath_paths).existing
+  def determine_rpath_paths(formula)
+    PATH.new(
+      (formula.lib unless formula.nil?),
+      PATH.new(determine_extra_rpath_paths).existing,
+    )
   end
 
   def determine_dynamic_linker_path(_formula)

--- a/Library/Homebrew/shims/linux/super/cc
+++ b/Library/Homebrew/shims/linux/super/cc
@@ -252,7 +252,7 @@ class Cmd
     args = []
     args += ["#{wl}--dynamic-linker=#{dynamic_linker_path}"] if dynamic_linker_path
     args += path_flags("-L", library_paths)
-    args += path_flags("#{wl}-rpath=", rpath_paths)
+    args += rpath_flags("#{wl}-rpath=", rpath_paths)
   end
 
   def isystem_paths
@@ -309,6 +309,12 @@ class Cmd
   def path_flags(prefix, paths)
     paths = paths.uniq.select { |path| File.directory?(path) }
     paths.map! { |path| prefix + path }
+  end
+
+  # Unlike path_flags, do not prune non-existant directories.
+  # formula.lib for example does not yet exist, but should not be pruned.
+  def rpath_flags(prefix, paths)
+    paths.uniq.map { |path| prefix + path }
   end
 
   def path_split(key)


### PR DESCRIPTION
Unlinked kegs, such as versioned kegs, need their lib directory in their RPATH.

See `openssl@1.1` as an example.