### PR TITLE
shims/linux/super/cc: Fix c++ -xc++-header for Linuxbrew

### DIFF
--- a/Library/Homebrew/shims/linux/super/cc
+++ b/Library/Homebrew/shims/linux/super/cc
@@ -44,6 +44,8 @@ class Cmd
       else
         :cc
       end
+    elsif @args.include?("-xc++-header") || @args.each_cons(2).include?(["-x", "c++-header"])
+      :cxx
     elsif @args.include? "-E"
       :ccE
     else


### PR DESCRIPTION
Compiling a precompiled header should be mode `:cxx` rather than `:cxxld`.