### PR TITLE
Dockerfile: Replace deprecated MAINTAINER command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:trusty
-MAINTAINER Shaun Jackman <sjackman@gmail.com>
+LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 
 RUN apt-get update \
 	&& apt-get install -y curl file g++ git make ruby2.0 ruby2.0-dev uuid-runtime \


### PR DESCRIPTION
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The MAINTAINER instruction is deprecated. Use a label instead.