### PR TITLE
Install bzip2 if required to decompress bz2 files

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -180,6 +180,7 @@ class DependencyCollector
     when ".rar"         then Dependency.new("unrar", tags)
     when ".7z"          then Dependency.new("p7zip", tags)
     when ".zip"         then Dependency.new("unzip", tags) unless OS.mac?
+    when ".bz2"         then Dependency.new("bzip2", tags) unless OS.mac?
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Without this, `brew install ncurses` fails on a fresh Ubuntu docker image because it tries to download a .bz2 file it can't decompress.