### PR TITLE
bottle: Fix --merge --write for Linuxbrew

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -432,6 +432,15 @@ module Homebrew
                 value = value_original.to_s
                 next if key == "cellar" && old_value == "any" && value == "any_skip_relocation"
                 next unless old_value.empty? || value != old_value
+
+                if key == "cellar" &&
+                   (old_value == "any" || old_value == "any_skip_relocation") &&
+                   value == "/home/linuxbrew/.linuxbrew/Cellar"
+                  opoo "#{formula_name}: #{key}: old: #{old_value}, new: #{value}"
+                  bottle.cellar old_value.to_sym
+                  next
+                end
+
                 old_value = old_value_original.inspect
                 value = value_original.inspect
                 mismatches << "#{key}: old: #{old_value}, new: #{value}"


### PR DESCRIPTION
Use the cellar value of macOS when macOS and Linux disagree.
Fix the error:
```
Error: --keep-old was passed but there are changes in:
cellar: old: ":any", new: "/home/linuxbrew/.linuxbrew/Cellar"
```