### PR TITLE
ELF: Improve the error message when ldd fails [Linux]

### DIFF
--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -55,7 +55,7 @@ module ELF
       end
       command = [ldd, path.expand_path.to_s]
       libs = Utils.popen_read(*command).split("\n")
-      raise ErrorDuringExecution, command unless $CHILD_STATUS.success?
+      raise ErrorDuringExecution, "#{command.join(" ")}\n#{libs.join("\n")}" unless $CHILD_STATUS.success?
       needed << "not found"
       libs.select! { |lib| needed.any? { |soname| lib.include? soname } }
       @dylibs = libs.map { |lib| lib[LDD_RX, 1] || lib[LDD_RX, 2] }.compact


### PR DESCRIPTION
Include the output of the failed command.
```
Error: Failure while executing: /home/sjackman/.linuxbrew/Cellar/glibc/2.23/bin/ldd /home/sjackman/.linuxbrew/Cellar/glibc/2.23/bin/gencat
/home/sjackman/.linuxbrew/Cellar/glibc/2.23/bin/ldd: /home/sjackman/.linuxbrew/Cellar/glibc/2.23/bin/gencat: /home/linuxbrew/.linuxbrew/Cellar/glibc/2.23/lib/ld-linux-x86-64.so.2: bad ELF interpreter: No such file or directory 
```
