### PR TITLE
link: Symlink glibc's ld.so before libc.so.6 [Linux]

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -408,6 +408,12 @@ class Keg
   end
 
   def link(mode = OpenStruct.new)
+    if OS.linux? && name == "glibc"
+      # Symlink ld.so before libc.so.6
+      ld_so = prefix/"lib/ld-linux-x86-64.so.2"
+      FileUtils.ln_sf ld_so, HOMEBREW_PREFIX/"lib/ld.so" if ld_so.readable?
+    end
+
     raise AlreadyLinkedError, self if linked_keg_record.directory?
 
     ObserverPathnameExtension.reset_counts!


### PR DESCRIPTION
Symlinking `libc.so.6` before `ld.so` causes havoc.