### PR TITLE
config: Use linked_version of a formula [Linux]

### DIFF
--- a/Library/Homebrew/extend/os/linux/system_config.rb
+++ b/Library/Homebrew/extend/os/linux/system_config.rb
@@ -22,9 +22,7 @@ class SystemConfig
 
     def formula_version(formula)
       return "N/A" unless CoreTap.instance.installed?
-      f = Formulary.factory formula
-      return "N/A" unless f.installed?
-      f.version
+      Formulary.factory(formula).linked_version || "N/A"
     rescue FormulaUnavailableError
       return "N/A"
     end


### PR DESCRIPTION
Otherwise when the keg was installed but out-of-date, it would display "N/A".