### PR TITLE
Dockerfile: Install ruby ruby-dev sudo [Linux]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 
 RUN apt-get update \
 	&& apt-get install -y bzip2 curl file g++ git locales make ruby-dev sudo uuid-runtime
+RUN mkdir -p /usr/share/rubygems-integration/all/gems/rake-10.5.0/bin \
+	&& ln -s /usr/bin/rake /usr/share/rubygems-integration/all/gems/rake-10.5.0/bin/
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
 	&& useradd -m -s /bin/bash linuxbrew \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:xenial
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 
 RUN apt-get update \
-	&& apt-get install -y curl file g++ git locales make uuid-runtime
+	&& apt-get install -y bzip2 curl file g++ git locales make ruby-dev sudo uuid-runtime
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
 	&& useradd -m -s /bin/bash linuxbrew \


### PR DESCRIPTION
`ruby-portable` has a couple of problems that prevents it from using `gem` to run `brew man` (for example).
The file `/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.0.0-p648/lib/ruby/2.0.0/x86_64-linux/rbconfig.rb` contains `-Wl,-search_paths_first` which breaks Ruby packages that require compiling C code. The resulting executables segfault.
```
$ /home/linuxbrew/.gem/ruby/2.0.0/bin/ronn
this executable file can't load extension libraries
```
The `ruby` executable does not appear to support loading shared extension libraries.