### PR TITLE
diagnostic: Replace use of deprecated shell_profile

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -507,7 +507,7 @@ module Homebrew
           this variable set to include other locations.
           Some programs like `vapigen` may not work correctly.
           Consider setting the XDG_DATA_DIRS for example like so
-              echo 'export XDG_DATA_DIRS="#{share}:$XDG_DATA_DIRS"' >> #{Utils::Shell.shell_profile}
+              echo 'export XDG_DATA_DIRS="#{share}:$XDG_DATA_DIRS"' >> #{Utils::Shell.profile}
         EOS
       end
 


### PR DESCRIPTION
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

---------

Running `brew doctor` can trigger the following:

```
Error: Calling Utils::Shell.shell_profile is deprecated!
Use Utils::Shell.profile instead.
/usr/local/Homebrew/Library/Homebrew/diagnostic.rb:510:in `check_xdg_data_dirs'
```