### PR TITLE
GlibcRequirement.system_version: Use Version::NULL [Linux]

### DIFF
--- a/Library/Homebrew/extend/os/linux/system_config.rb
+++ b/Library/Homebrew/extend/os/linux/system_config.rb
@@ -14,6 +14,12 @@ class SystemConfig
       end
     end
 
+    def host_glibc_version
+      version = GlibcRequirement.system_version
+      return "N/A" if version.null?
+      version
+    end
+
     def host_gcc_version
       gcc = Pathname.new "/usr/bin/gcc"
       return "N/A" unless gcc.executable?
@@ -31,7 +37,7 @@ class SystemConfig
       dump_generic_verbose_config(out)
       out.puts "Kernel: #{`uname -mors`.chomp}"
       out.puts "OS: #{host_os_version}"
-      out.puts "Host glibc: #{GlibcRequirement.system_version}"
+      out.puts "Host glibc: #{host_glibc_version}"
       out.puts "/usr/bin/gcc: #{host_gcc_version}"
       ["glibc", "gcc", "xorg"].each do |f|
         out.puts "#{f}: #{formula_version f}"

--- a/Library/Homebrew/requirements/glibc_requirement.rb
+++ b/Library/Homebrew/requirements/glibc_requirement.rb
@@ -10,10 +10,10 @@ class GlibcRequirement < Requirement
     libc = ["/lib/x86_64-linux-gnu/libc.so.6", "/lib64/libc.so.6", "/usr/lib64/libc.so.6", "/lib/libc.so.6", "/usr/lib/libc.so.6", "/lib/i386-linux-gnu/libc.so.6", "/lib/arm-linux-gnueabihf/libc.so.6"].find do |s|
       Pathname.new(s).executable?
     end
-    raise "Unable to locate the system's glibc" unless libc
+    return Version::NULL unless libc
     version = Utils.popen_read("#{libc} 2>&1")[/[Vv]ersion (\d\.\d+)/, 1]
-    raise "Unable to determine the system's glibc version" unless version
-    @system_version = version
+    return Version::NULL unless version
+    @system_version = Version.new version
   end
 
   satisfy(build_env: false) do


### PR DESCRIPTION
Return Version::NULL when unable to identify the host's
version of glibc rather than emitting an error.

Alpine Linux uses musl libc rather than glibc.

The return type of `GlibcRequirement.system_version` was `String` and is now `Version`.