### PR TITLE
Silence two brew audit errors

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -598,7 +598,8 @@ class FormulaAuditor
     return if metadata.nil?
 
     problem "GitHub fork (not canonical repository)" if metadata["fork"]
-    if (metadata["forks_count"] < 20) && (metadata["subscribers_count"] < 20) &&
+    if user.casecmp("homebrew").zero? &&
+       (metadata["forks_count"] < 20) && (metadata["subscribers_count"] < 20) &&
        (metadata["stargazers_count"] < 50)
       problem "GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)"
     end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -456,7 +456,7 @@ class FormulaAuditor
           problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
         end
 
-        if @new_formula && dep_f.keg_only_reason &&
+        if OS.mac? && @new_formula && dep_f.keg_only_reason &&
            !["openssl", "apr", "apr-util"].include?(dep.name) &&
            [:provided_by_macos, :provided_by_osx].include?(dep_f.keg_only_reason.reason)
           problem "Dependency '#{dep.name}' may be unnecessary as it is provided by macOS; try to build this formula without it."


### PR DESCRIPTION
Silence "GitHub repository not notable" on non-Homebrew taps.
Silence "Dependency may be unnecessary" on non-macOS systems.