### PR TITLE
audit: Disable OS.mac? and OS.linux? audit [Linux]

### DIFF
--- a/Library/Homebrew/rubocops/lines_cop.rb
+++ b/Library/Homebrew/rubocops/lines_cop.rb
@@ -75,6 +75,7 @@ module RuboCop
           end
 
           [:mac?, :linux?].each do |method_name|
+            next if @file_path.include? "/.linuxbrew/"
             next unless formula_tap == "homebrew-core"
             find_instance_method_call(body_node, "OS", method_name) do |check|
               problem "Don't use #{check.source}; Homebrew/core only supports macOS"

--- a/Library/Homebrew/test/rubocops/lines_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_cop_spec.rb
@@ -226,7 +226,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       end
     end
 
-    it "with OS.linux? check" do
+    it "with OS.linux? check", :needs_macos do
       source = <<-EOS.undent
         class Foo < Formula
           desc "foo"


### PR DESCRIPTION
Fix the error:
```
Don't use OS.mac?; Homebrew/core only supports macOS
```