### PR TITLE
super/cc: Specify search path for crt1.o in cflags [Linux]

### DIFF
--- a/Library/Homebrew/shims/linux/super/cc
+++ b/Library/Homebrew/shims/linux/super/cc
@@ -253,7 +253,7 @@ class Cmd
     wl = "-Wl," unless mode == :ld
     args = []
     args += ["#{wl}--dynamic-linker=#{dynamic_linker_path}"] if dynamic_linker_path
-    args << "-B#{@opt}/glibc/lib"
+    args << "-B#{@opt}/glibc/lib" unless mode == :ld
     args += path_flags("-L", library_paths)
     args += rpath_flags("#{wl}-rpath=", rpath_paths)
   end


### PR DESCRIPTION
The `-B` option is valid for cc but not for ld.
Fix the error:
```
ld: unrecognized option '-B/home/linuxbrew/.linuxbrew/opt/glibc/lib'
```