### PR TITLE
Retain CircleCI environment variables [Linux]

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -92,9 +92,9 @@ then
   PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
   FILTERED_ENV=()
-  for VAR in HOME SHELL PATH TERM LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
+  for VAR in HOME SHELL PATH TERM LOGNAME USER CI CIRCLECI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy HTTPS_PROXY FTP_PROXY \
-             "${!HOMEBREW_@}" "${!TRAVIS_@}" "${!JENKINS_@}"
+             "${!HOMEBREW_@}" "${!CI_@}" "${!CIRCLE_@}" "${!TRAVIS_@}" "${!JENKINS_@}"
   do
     # Skip if variable value is empty.
     [[ -z "${!VAR}" ]] && continue


### PR DESCRIPTION
Protect the CircleCI environment variables from ENV_FILTER:
`CIRCLECI`, `CIRCLE_*`, and `CI_*`