### PR TITLE
shims/scm/git: Fix the search for brewed git

### DIFF
--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -92,6 +92,9 @@ case "$(lowercase "$SCM_FILE")" in
     ;;
 esac
 
+brew_version="$(quiet_safe_cd "$SCM_DIR/../../../../../bin" && pwd -P)/$SCM_FILE"
+safe_exec "$brew_version" "$@"
+
 brew_version="$(quiet_safe_cd "$SCM_DIR/../../../../bin" && pwd -P)/$SCM_FILE"
 safe_exec "$brew_version" "$@"
 


### PR DESCRIPTION
Search for brewed git in both locations:
```
$HOMEBREW_PREFIX/Homebrew/Library/Homebrew/shims/scm/../../../../../bin/git
$HOMEBREW_PREFIX/Library/Homebrew/shims/scm/../../../../bin/git
```