### PR TITLE
DevelopmentTools.installed?: Use locate

### DIFF
--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -18,7 +18,7 @@ class DevelopmentTools
     end
 
     def installed?
-      which("clang") || which("gcc")
+      locate("clang") || locate("gcc")
     end
 
     def installation_instructions


### PR DESCRIPTION
Use locate rather than which to search for clang or gcc.
locate searches both $HOMEBREW_PREFIX/bin and /usr/bin.