### PR TITLE
MacOS::Xcode.version: Return Version::NULL on Linux

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -149,7 +149,9 @@ module OS
         # installed CLT version. This is useful as they are packaged
         # simultaneously so workarounds need to apply to both based on their
         # comparable version.
-        case (DevelopmentTools.clang_version.to_f * 10).to_i
+        clang_version = DevelopmentTools.clang_version
+        return nil if clang_version.null?
+        case (clang_version.to_f * 10).to_i
         when 0       then "dunno"
         when 1..14   then "3.2.2"
         when 15      then "3.2.4"


### PR DESCRIPTION
MacOS::Xcode.version threw the exception
```
Error: NaN
Library/Homebrew/os/mac/xcode.rb:152:in `to_i'
```

This caused `brew audit qt` to fail when it parses old versions of the formula.