### PR TITLE
Python.user_site_packages: Ensure python exists

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -42,6 +42,9 @@ module Language
     end
 
     def self.user_site_packages(python)
+      if !OS.mac? && which(python).nil?
+        return Pathname.new("#{ENV["HOME"]}/.local/lib/python2.7/site-packages")
+      end
       Pathname.new(`#{python} -c "import site; print(site.getusersitepackages())"`.chomp)
     end
 


### PR DESCRIPTION
Fix the error:
```
brew info python
...
--HEAD
    Install HEAD version
sh: 1: python: not found
sh: 1: python: not found
==> Caveats
...
```
  