### PR TITLE
check_install_sanity: Use formula.runtime_dependencies [Linux]

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -150,7 +150,7 @@ class FormulaInstaller
 
     recursive_deps = formula.recursive_dependencies
     recursive_formulae = recursive_deps.map(&:to_formula)
-    recursive_runtime_deps = formula.recursive_dependencies.reject(&:build?)
+    recursive_runtime_deps = formula.runtime_dependencies
     recursive_runtime_formulae = recursive_runtime_deps.map(&:to_formula)
 
     recursive_dependencies = []


### PR DESCRIPTION
Fix
```
$ brew install wget
Error: wget contains conflicting version recursive dependencies:
openssl, openssl@1.1
View these with `brew deps --tree wget`.
$ brew deps --tree wget
wget
├── libidn2
│ └── libunistring
├── openssl@1.1
│ └── perl
│ ├── gdbm
│ ├── berkeley-db
│ └── expat
│ └── libbsd
└── util-linux
└── ncurses
```