### PR TITLE
Python.user_site_packages: Check python suceeds [Linux]

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -42,10 +42,11 @@ module Language
     end
 
     def self.user_site_packages(python)
-      if !OS.mac? && which(python).nil?
+      output = Utils.popen_read(python, "-c", "import site; print(site.getusersitepackages())").chomp
+      if !$CHILD_STATUS.success? || output.empty?
         return Pathname.new("#{ENV["HOME"]}/.local/lib/python2.7/site-packages")
       end
-      Pathname.new(`#{python} -c "import site; print(site.getusersitepackages())"`.chomp)
+      Pathname.new(output)
     end
 
     def self.in_sys_path?(python, path)


### PR DESCRIPTION
Python 2.6 does not provide site.getusersitepackages()
Fix...
```
AttributeError: 'module' object has no attribute 'getusersitepackages'
```