### PR TITLE
X11Requirement: Check xdpyinfo if Xorg fails [Linux]

### DIFF
--- a/Library/Homebrew/requirements/x11_requirement.rb
+++ b/Library/Homebrew/requirements/x11_requirement.rb
@@ -24,20 +24,16 @@ class X11Requirement < Requirement
 
   satisfy build_env: false do
     if which_xorg = which("Xorg")
-      version = Utils.popen_read which_xorg, "-version", err: :out
-      next false unless $CHILD_STATUS.success?
-      version = version[/X Server (\d+\.\d+\.\d+)/, 1]
-      next false unless version
-      Version.new(version) >= min_version
-    elsif which_xdpyinfo = which("xdpyinfo")
-      version = Utils.popen_read which_xdpyinfo, "-version"
-      next false unless $CHILD_STATUS.success?
-      version = version[/^xdpyinfo (\d+\.\d+\.\d+)/, 1]
-      next false unless version
-      Version.new(version) >= min_xdpyinfo_version
-    else
-      false
+      version = Utils.popen_read(which_xorg, "-version", err: :out)[/X Server (\d+\.\d+\.\d+)/, 1]
+      next true if $CHILD_STATUS.success? && version && Version.new(version) >= min_version
     end
+
+    if which_xdpyinfo = which("xdpyinfo")
+      version = Utils.popen_read(which_xdpyinfo, "-version")[/^xdpyinfo (\d+\.\d+\.\d+)/, 1]
+      next true if $CHILD_STATUS.success? && version && Version.new(version) >= min_xdpyinfo_version
+    end
+
+    false
   end
 
   def message


### PR DESCRIPTION
`Xorg -version` fails if the user does not have console ownership.

Fix the error:
```
$ Xorg -version
Fatal server error:
PAM authentication failed, cannot start X server.
Perhaps you do not have console ownership?
```

Fixes https://github.com/Linuxbrew/brew/issues/580