### PR TITLE
change_rpath: Use patchelf --force-rpath [Linux]

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -31,7 +31,7 @@ class Keg
     lib_path = "#{new_prefix}/lib"
     rpath << lib_path unless rpath.include? lib_path
     new_rpath = rpath.join(":")
-    cmd = [patchelf, "--set-rpath", new_rpath]
+    cmd = [patchelf, "--force-rpath", "--set-rpath", new_rpath]
 
     if file.binary_executable?
       cmd_interpreter = [patchelf, "--print-interpreter", file]


### PR DESCRIPTION
Use `RPATH` rather than `RUNPATH`.
`RPATH` takes precedence over `LD_LIBRARY_PATH`.