### PR TITLE
Dockerfile: Add --no-install-recommends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:xenial
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 
 RUN apt-get update \
-	&& apt-get install -y bzip2 curl file g++ git locales make sudo uuid-runtime
+	&& apt-get install -y --no-install-recommends curl file g++ git locales make sudo uuid-runtime \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
 	&& useradd -m -s /bin/bash linuxbrew \


### PR DESCRIPTION
Do not install bzip2.
Remove the files created by apt-get update.