### PR TITLE
Dockerfile: Install ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:xenial
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends curl file g++ git locales make sudo uuid-runtime \
+	&& apt-get install -y --no-install-recommends ca-certificates curl file g++ git locales make sudo uuid-runtime \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \


### PR DESCRIPTION
Fix the error:
```
fatal: unable to access 'https://github.com/Linuxbrew/homebrew-core/':
Problem with the SSL CA cert (path? access rights?)
```