### PR TITLE
Dockerfile: Install bzip2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:xenial
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates curl file g++ git locales make sudo uuid-runtime \
+	&& apt-get install -y --no-install-recommends bzip2 ca-certificates curl file g++ git locales make sudo uuid-runtime \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \


### PR DESCRIPTION
brew tests requires bzip2. Fix the error:
```
tar (child): bzip2: Cannot exec: No such file or directory
```