### PR TITLE
Revert "Tap.from_file_content: Fix for Linuxbrew"

### DIFF
--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -75,13 +75,6 @@ class Tab < OpenStruct
       attributes["source"]["tap"] = "homebrew/core"
     end
 
-    case attributes["source"]["tap"]
-    when "linuxbrew/dupes"
-      attributes["source"]["tap"] = "homebrew/dupes"
-    when "linuxbrew/science"
-      attributes["source"]["tap"] = "homebrew/science"
-    end
-
     if attributes["source"]["spec"].nil?
       version = PkgVersion.parse path.to_s.split("/")[-2]
       if version.head?


### PR DESCRIPTION
This reverts commit 5263c7fe838e0bc95e08cf1d5e7de856d5de36a5.
Linuxbrew/dupes and Linuxbrew/science have been removed.