### PR TITLE
DependencyCollector: Add java_dep_if_needed [Linux]

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -78,6 +78,10 @@ class DependencyCollector
     Dependency.new("bzip2", tags) unless which("bzip2")
   end
 
+  def java_dep_if_needed(tags)
+    JavaRequirement.new(tags)
+  end
+
   def ld64_dep_if_needed(*); end
 
   def self.tar_needs_xz_dependency?
@@ -120,7 +124,7 @@ class DependencyCollector
     when :linux      then LinuxRequirement.new(tags)
     when :macos      then MacOSRequirement.new(tags)
     when :arch       then ArchRequirement.new(tags)
-    when :java       then JavaRequirement.new(tags)
+    when :java       then java_dep_if_needed(tags)
     when :osxfuse    then OsxfuseRequirement.new(tags)
     when :tuntap     then TuntapRequirement.new(tags)
     when :ld64       then ld64_dep_if_needed(tags)

--- a/Library/Homebrew/extend/os/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/dependency_collector.rb
@@ -1,2 +1,6 @@
 require "dependency_collector"
-require "extend/os/mac/dependency_collector" if OS.mac?
+if OS.mac?
+  require "extend/os/mac/dependency_collector"
+elsif OS.linux?
+  require "extend/os/linux/dependency_collector"
+end

--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -1,0 +1,14 @@
+class DependencyCollector
+  def java_dep_if_needed(tags)
+    req = JavaRequirement.new(tags)
+    begin
+      Formula["jdk"]
+      dep = Dependency.new("jdk", tags)
+      return dep if dep.installed?
+      return req if req.satisfied?
+      dep
+    rescue FormulaUnavailableError
+      req
+    end
+  end
+end


### PR DESCRIPTION
Use the jdk formula if it's installed.
Use the host's Java if it's sufficient.
Otherwise install the jdk formula.