### PR TITLE
check_undeclared_deps: Fix for taps

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -86,7 +86,7 @@ class LinkageChecker
       formula.build.without?(dep)
     end
     declared_deps = formula.deps.reject { |dep| filter_out.call(dep) }.map(&:name)
-    recursive_deps = keg.to_formula.runtime_dependencies.map { |dep| dep.to_formula.full_name }
+    recursive_deps = keg.to_formula.runtime_dependencies.map { |dep| dep.to_formula.name }
     declared_dep_names = declared_deps.map { |dep| dep.split("/").last }
     indirect_deps = []
     undeclared_deps = []


### PR DESCRIPTION
`undeclared_deps` reports all dependencies in taps as undeclared.
