### PR TITLE
test: Revert Linux-specific changes

### DIFF
--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -20,10 +20,6 @@ begin
     ENV.setup_build_environment
   else
     ENV.setup_build_environment(formula)
-    # Add the python executable to the PATH.
-    if formula.deps.map(&:name).include? "python"
-      ENV.append_path "PATH", "#{HOMEBREW_PREFIX}/opt/python/libexec/bin"
-    end
   end
 
   trap("INT", old_trap)

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -16,11 +16,7 @@ begin
 
   ENV.extend(Stdenv)
   formula = ARGV.formulae.first
-  if OS.mac?
-    ENV.setup_build_environment
-  else
-    ENV.setup_build_environment(formula)
-  end
+  ENV.setup_build_environment
 
   trap("INT", old_trap)
 


### PR DESCRIPTION
- Call ENV.setup_build_environment without formula
    This chunk should no longer be needed now that GCC 5 is used throughout.
- Do not add python to PATH in test env
    Since python@2 is keg-only, it is not expected to be found in the user's PATH