### PR TITLE
Dockerfile: Install fonts-dejavu-core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:xenial
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends bzip2 ca-certificates curl file g++ git locales make openssh-client patch sudo uuid-runtime \
+	&& apt-get install -y --no-install-recommends bzip2 ca-certificates curl file fonts-dejavu-core g++ git locales make openssh-client patch sudo uuid-runtime \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \


### PR DESCRIPTION
`brew test graphviz` fails with fonts installed. There may be other GUI applications that fail without fonts. We don't yet have a fonts package for Linuxbrew, though we could.