### PR TITLE
Add arm64 link loader

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -332,7 +332,14 @@ module Homebrew
   def symlink_ld_so
     ld_so = HOMEBREW_PREFIX/"lib/ld.so"
     return if ld_so.readable?
-    sys_interpreter = ["/lib64/ld-linux-x86-64.so.2", "/lib/ld-linux.so.3", "/lib/ld-linux.so.2", "/lib/ld-linux-armhf.so.3", "/system/bin/linker"].find do |s|
+    sys_interpreter = [
+      "/lib64/ld-linux-x86-64.so.2",
+      "/lib/ld-linux.so.3",
+      "/lib/ld-linux.so.2",
+      "/lib/ld-linux-armhf.so.3",
+      "/lib/ld-linux-aarch64.so.1",
+      "/system/bin/linker",
+    ].find do |s|
       Pathname.new(s).executable?
     end
     raise "Unable to locate the system's ld.so" unless sys_interpreter


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
       4 fails not related to this pull request (please refer my comment below)
-----
This pull request enables Linuxbrew to run on arm64/aarch64 Linux environment.
Please have a look.

All failed tests are because of missing `Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.aarch64_linux.bottle.tar.gz`.

1. >Formulary::factory returns a Formula when given a bottle
     Failure/Error: formula = subject.factory(bottle)
     Errno::ENOENT:
       No such file or directory @ realpath_rec - <Homebrew>/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.aarch64_linux.bottle.tar.gz
2. >Formulary::factory with installed Formula returns a Formula when given a rack
     Failure/Error: installer.install
     DownloadError:
       Failed to download resource "testball_bottle"
       File does not exist: <Homebrew>/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.aarch64_linux.bottle.tar.gz
3. >Formulary::factory with installed Formula returns a Formula when given a Keg
     Failure/Error: installer.install
     DownloadError:
       Failed to download resource "testball_bottle"
       File does not exist: <Homebrew>/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.aarch64_linux.bottle.tar.gz
4. >FormulaInstaller basic bottle install
     Failure/Error: described_class.new(formula).install
     DownloadError:
       Failed to download resource "testball_bottle"
       File does not exist: <Homebrew>/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.aarch64_linux.bottle.tar.gz
