### PR TITLE
DevelopmentTools#locate: do not search for gcc@* formula

### DIFF
--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -6,12 +6,13 @@ class DevelopmentTools
       # Give the name of the binary you look for as a string to this method
       # in order to get the full path back as a Pathname.
       (@locate ||= {}).fetch(tool) do |key|
-        @locate[key] = if !OS.mac? && (path = HOMEBREW_PREFIX/"bin/#{tool}").executable?
+        @locate[key] = if !OS.mac? && (path = HOMEBREW_PREFIX/"bin/#{tool}").executable? &&
+                          !path.realpath.to_s.start_with?("#{HOMEBREW_CELLAR}/gcc@") # skip gcc@* formula
           path
         elsif File.executable?(path = "/usr/bin/#{tool}")
           Pathname.new path
         # Homebrew GCCs most frequently; much faster to check this before xcrun
-        elsif (path = HOMEBREW_PREFIX/"bin/#{tool}").executable?
+        elsif OS.mac? && (path = HOMEBREW_PREFIX/"bin/#{tool}").executable?
           path
         end
       end


### PR DESCRIPTION

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We should never use gcc@* as the default compiler.
Otherwise, the bottle will be linked to the wrong gcc libraries.

Instead, we should only use gcc main formula or the system compiler.
