### PR TITLE
Compiler: add :brew_gcc

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -8,6 +8,7 @@ module CompilerConstants
     "clang"      => :clang,
     "llvm_clang" => :llvm_clang,
     "cc"         => :c_compiler,
+    "gcc"        => :brew_gcc,
   }.freeze
 
   COMPILERS = COMPILER_SYMBOL_MAP.values +
@@ -102,7 +103,7 @@ class CompilerSelector
     clang: [:clang, :gcc_4_2, :gnu, :gcc_4_0, :llvm_clang],
     gcc_4_2: [:gcc_4_2, :gnu, :clang, :gcc_4_0],
     gcc_4_0: [:gcc_4_0, :gcc_4_2, :gnu, :clang],
-    c_compiler: [:gnu, :clang, :gcc_4_2, :gcc_4_0, :llvm_clang],
+    c_compiler: [:brew_gcc, :gnu, :clang, :gcc_4_2, :gcc_4_0, :llvm_clang],
   }.freeze
 
   def self.select_for(formula, compilers = self.compilers)

--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -118,10 +118,25 @@ class DevelopmentTools
       non_apple_gcc_version "cc"
     end
 
+    def brew_gcc_build_version
+      @brew_gcc_build_version ||= begin
+        path = Formulary.factory("gcc").opt_bin/"gcc"
+        if path.executable? &&
+           build_version = `#{path} --version`[/g?cc(?:(?:-\d(?:\.\d)?)? \(.+\))? (\d\.\d\.\d)/, 1]
+          Version.new build_version
+        else
+          Version::NULL
+        end
+      rescue FormulaUnavailableError
+        Version::NULL
+      end
+    end
+
     def clear_version_cache
       @gcc_4_0_build_version = @gcc_4_2_build_version = nil
       @clang_version = @clang_build_version = nil
       @non_apple_gcc_version = {}
+      @brew_gcc_build_version = nil
     end
 
     def curl_handles_most_https_certificates?

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -16,6 +16,15 @@ module Superenv
   def homebrew_extra_paths
     paths = []
 
+    if compiler == :brew_gcc
+      bin = begin
+        Formula["gcc"].opt_bin
+      rescue FormulaUnavailableError
+        nil
+      end
+      paths << bin if bin&.directory?
+    end
+
     paths += %w[binutils make].map do |f|
       begin
         bin = Formula[f].opt_bin


### PR DESCRIPTION
We should never use `gcc@*` as the default compiler.
Otherwise, the bottle will be linked to the wrong gcc libraries.

To properly solve the above issue, we introduce a new compiler type
`:brew_gcc` and give it the highest priority.

This replaces #670.