### PR TITLE
Compiler: avoid gcc@* formula

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -129,11 +129,15 @@ class CompilerSelector
 
   private
 
+  def gnu_gcc_versions
+    GNU_GCC_VERSIONS
+  end
+
   def find_compiler
     compilers.each do |compiler|
       case compiler
       when :gnu
-        GNU_GCC_VERSIONS.reverse_each do |v|
+        gnu_gcc_versions.reverse_each do |v|
           name = "gcc-#{v}"
           version = compiler_version(name)
           yield Compiler.new(name, version) unless version.null?
@@ -160,3 +164,5 @@ class CompilerSelector
     end
   end
 end
+
+require "extend/os/compilers"

--- a/Library/Homebrew/extend/os/compilers.rb
+++ b/Library/Homebrew/extend/os/compilers.rb
@@ -1,0 +1,1 @@
+require "extend/os/linux/compilers" if OS.linux?

--- a/Library/Homebrew/extend/os/linux/compilers.rb
+++ b/Library/Homebrew/extend/os/linux/compilers.rb
@@ -1,0 +1,8 @@
+class CompilerSelector
+  def gnu_gcc_versions
+    v = Formulary.factory("gcc").version.to_s.slice(/\d/)
+    GNU_GCC_VERSIONS - [v] + [v]
+  rescue FormulaUnavailableError
+    GNU_GCC_VERSIONS
+  end
+end


### PR DESCRIPTION
We should never use gcc@* as the default compiler.
Otherwise, the bottle will be linked to the wrong gcc libraries.

This replaces #670, #674 