### PR TITLE
Dockerfile: Use HOMEBREW_NO_AUTO_UPDATE=1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 	USER=linuxbrew
 
 # Install portable-ruby and tap homebrew/core.
-RUN HOMEBREW_NO_ANALYTICS=1 brew tap homebrew/core \
+RUN HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/core \
 	&& rm -rf ~/.cache


### PR DESCRIPTION
Use `HOMEBREW_NO_AUTO_UPDATE=1` to avoid resetting Linuxbrew/brew
back to the most recent stable tagged release.