### PR TITLE
Clean up cross-platform diagnostic

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -27,6 +27,21 @@ module Homebrew
         ]).freeze
       end
 
+      def check_for_non_prefixed_findutils
+        findutils = Formula["findutils"]
+        return unless findutils.any_version_installed?
+
+        gnubin = %W[#{findutils.opt_libexec}/gnubin #{findutils.libexec}/gnubin]
+        default_names = Tab.for_name("findutils").with? "default-names"
+        return if !default_names && (paths & gnubin).empty?
+
+        <<~EOS
+          Putting non-prefixed findutils in your path can cause python builds to fail.
+        EOS
+      rescue FormulaUnavailableError
+        nil
+      end
+
       def check_for_unsupported_macos
         return if ARGV.homebrew_developer?
 

--- a/Library/Homebrew/test/diagnostic_spec.rb
+++ b/Library/Homebrew/test/diagnostic_spec.rb
@@ -154,11 +154,6 @@ describe Homebrew::Diagnostic::Checks do
     end
   end
 
-  specify "#check_dyld_vars", :needs_macos do
-    ENV["DYLD_INSERT_LIBRARIES"] = "foo"
-    expect(subject.check_dyld_vars).to match("Setting DYLD_INSERT_LIBRARIES")
-  end
-
   specify "#check_for_symlinked_cellar" do
     begin
       HOMEBREW_CELLAR.rmtree

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -45,4 +45,9 @@ describe Homebrew::Diagnostic::Checks do
     expect(subject.check_ruby_version)
       .to match "Ruby version 1.8.6 is unsupported on 10.12"
   end
+
+  specify "#check_dyld_vars" do
+    ENV["DYLD_INSERT_LIBRARIES"] = "foo"
+    expect(subject.check_dyld_vars).to match("Setting DYLD_INSERT_LIBRARIES")
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
`check_tmpdir_executable`  and   `check_tmpdir_executable` now live in `extend/os/linux/diagnostic.rb`

moving `check_for_non_prefixed_findutils` to `extend/os/mac/diagnostic.rb`


`brew style Library/Homebrew/diagnostic.rb` reports some errors but these are from upstream
```
== Library/Homebrew/diagnostic.rb ==
C: 10: 27: Method parameter must be at least 3 characters long.
C: 13: 55: Use hash rockets syntax.
C:673: 31: Method parameter must be at least 3 characters long.
```