### PR TITLE
Simplify `search_taps` method and handle errors

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -110,15 +110,22 @@ module Homebrew
       $stderr.puts Formatter.headline("Searching taps on GitHub...", color: :blue)
     end
 
-    valid_dirnames = ["Formula", "HomebrewFormula", "Casks", "."].freeze
-    matches = GitHub.search_code(user: ["Homebrew", "caskroom"], filename: query, extension: "rb")
-
+    matches = begin
+      GitHub.search_code(
+        user: ["Homebrew", "caskroom"],
+        path: ["Formula", "HomebrewFormula", "Casks", "."],
+        filename: query,
+        extension: "rb",
+      )
+    rescue GitHub::Error => error
+      opoo "Error searching on GitHub: #{error}\n"
+      []
+    end
     matches.map do |match|
-      dirname, filename = File.split(match["path"])
-      next unless valid_dirnames.include?(dirname)
+      filename = File.basename(match["path"], ".rb")
       tap = Tap.fetch(match["repository"]["full_name"])
       next if tap.installed? && match["repository"]["owner"]["login"] != "caskroom"
-      "#{tap.name}/#{File.basename(filename, ".rb")}"
+      "#{tap.name}/#{filename}"
     end.compact
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? **I linked to the equivalent PR in Homebrew**
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).  **See Homebrew PR**
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

### This commit and corresponding PR is identical to [Homebrew/brew PR4027](https://github.com/Homebrew/brew/pull/4027).

---

This commit simplifies the code for the `search_taps` method called by a user with `brew search`.

The logic currently searches more broadly, and then processes the JSON response locally to filter some results out.  This proposed change makes the search more specific to avoid having to filter out the response.

Simpler code is easier to maintain (and more newbie friendly), and potentially easier to troubleshoot bugs like #3834 (which is what led me to this).  It seems reasonable to expect that with some [considerable?] effort, the search functionality in each of `cask` and `brew` could be unified.

Additionally, I've borrowed the begin/rescue error handling logic from the cask-specific `search_remote` method.  This allows `brew search` to continue its check for "blacklisted, migrated and deleted formulae" despite a failure in the original `search_code` method.  Despite the fact that this encourages a second query to an API that's just errored out, it seems like a better practice than just failing on the error.

:beers:
