### PR TITLE
CPU::OPTIMIZATION_FLAGS: Add arm [Linux]

### DIFF
--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -9,6 +9,7 @@ module Hardware
       OPTIMIZATION_FLAGS = {
         core2: "-march=core2",
         core: "-march=prescott",
+        arm: "-march=armv6",
         dunno: "-march=native",
       }.freeze
 


### PR DESCRIPTION
Fix `brew install --build-bottle` for ARM.
Fix `Error: key not found: :arm`