### PR TITLE
CPU: Add armv6 and armv8

### DIFF
--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -9,7 +9,7 @@ module Hardware
       OPTIMIZATION_FLAGS = {
         core2: "-march=core2",
         core: "-march=prescott",
-        arm: "-march=armv6",
+        armv6: "-march=armv6",
         dunno: "-march=native",
       }.freeze
 
@@ -148,6 +148,8 @@ module Hardware
       else
         :core
       end
+    elsif Hardware::CPU.arm?
+      :armv6
     else
       Hardware::CPU.family
     end

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -10,6 +10,7 @@ module Hardware
         core2: "-march=core2",
         core: "-march=prescott",
         armv6: "-march=armv6",
+        armv8: "-march=armv8-a",
         dunno: "-march=native",
       }.freeze
 
@@ -149,7 +150,11 @@ module Hardware
         :core
       end
     elsif Hardware::CPU.arm?
-      :armv6
+      if Hardware::CPU.is_64_bit?
+        :armv8
+      else
+        :armv6
+      end
     else
       Hardware::CPU.family
     end


### PR DESCRIPTION
The bottling architecture of 32-bit ARM is armv6.
The bottling architecture of 64-bit ARM is armv8-a.