### PR TITLE
determine_dynamic_linker_path: Remove glibc special case [Linux]

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -63,7 +63,7 @@ module Superenv
     self["HOMEBREW_INCLUDE_PATHS"] = determine_include_paths
     self["HOMEBREW_LIBRARY_PATHS"] = determine_library_paths
     self["HOMEBREW_RPATH_PATHS"] = determine_rpath_paths(formula)
-    self["HOMEBREW_DYNAMIC_LINKER"] = determine_dynamic_linker_path(formula)
+    self["HOMEBREW_DYNAMIC_LINKER"] = determine_dynamic_linker_path
     self["HOMEBREW_DEPENDENCIES"] = determine_dependencies
     self["HOMEBREW_FORMULA_PREFIX"] = formula.prefix unless formula.nil?
 
@@ -208,7 +208,7 @@ module Superenv
     )
   end
 
-  def determine_dynamic_linker_path(_formula)
+  def determine_dynamic_linker_path
     ""
   end
 

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -36,8 +36,7 @@ module Superenv
     paths
   end
 
-  def determine_dynamic_linker_path(formula)
-    return "" if formula&.name == "glibc"
+  def determine_dynamic_linker_path
     "#{HOMEBREW_PREFIX}/lib/ld.so"
   end
 


### PR DESCRIPTION
The glibc clears the environment variable HOMEBREW_DYNAMIC_LINKER.