### PR TITLE
shims/super/cc: Use cc on Linux

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -414,7 +414,7 @@ end
 if __FILE__ == $PROGRAM_NAME
   ##################################################################### sanity
 
-  if (cc = ENV["HOMEBREW_CC"]).nil? || cc.empty? || cc == "cc"
+  if (cc = ENV["HOMEBREW_CC"]).nil? || cc.empty? || (mac? && cc == "cc")
     # those values are not allowed
     ENV["HOMEBREW_CC"] = "clang"
   end


### PR DESCRIPTION
Address the error
```
.../shims/linux/super/cc:440:in `exec': No such file or directory - clang (Errno::ENOENT)
```

See this failed Docker Hub build:
https://hub.docker.com/r/bcgsc/tigmint/builds/bd6bopkjfmbyn9q4bdacsgm/