### PR TITLE
shims/super/cc: Use -idirafter instead of -isystem [Linux]

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -270,6 +270,7 @@ class Cmd
   end
 
   def cppflags
+    isystem = mac? ? "-isystem" : "-idirafter"
     path_flags("-isystem", isystem_paths) + path_flags("-I", include_paths)
   end
 


### PR DESCRIPTION
Fix
```
error: stdlib.h: No such file or directory
 #include_next <stdlib.h>
```
See https://github.com/Linuxbrew/brew/issues/724