### PR TITLE
tap: Fix slug for ssh [Linux]

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -343,7 +343,7 @@ class BottleSpecification
 
   def root_url(var = nil, specs = {})
     if var.nil?
-      default_domain = (tap&.linux?) ? HOMEBREW_BOTTLE_DEFAULT_DOMAIN_LINUX : HOMEBREW_BOTTLE_DEFAULT_DOMAIN
+      default_domain = (!OS.mac? || tap&.linux?) ? HOMEBREW_BOTTLE_DEFAULT_DOMAIN_LINUX : HOMEBREW_BOTTLE_DEFAULT_DOMAIN
       domain = ENV.key?("HOMEBREW_BOTTLE_DOMAIN") ? HOMEBREW_BOTTLE_DOMAIN : default_domain
       @root_url ||= "#{domain}/#{Utils::Bottles::Bintray.repository(tap)}"
     else

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -115,12 +115,11 @@ class Tap
   # Not simply "#{user}/homebrew-#{repo}", because the slug of homebrew/core
   # may be either Homebrew/homebrew-core or Linuxbrew/homebrew-core.
   def slug
-    if remote.nil?
-      "#{user}/homebrew-#{repo}"
-    else
-      x = remote[%r{^https://github\.com/([^.]+)(\.git)?$}, 1]
-      (official? && !x.nil?) ? x.capitalize : x
-    end
+    default_slug = "#{user}/homebrew-#{repo}"
+    return default_slug if remote.nil?
+    x = remote[%r{^(?:https://github\.com/|git@github\.com:)([^.]+)(\.git)?$}, 1]
+    return default_slug if x.nil?
+    official? ? x.capitalize : x
   end
 
   # The default remote path to this {Tap}.


### PR DESCRIPTION
Fix
```
Error: undefined method `start_with?' for nil:NilClass
```

root_url: Default bottle domain is Linuxbrew [Linux]

On Linux the default bottle domain is Linuxbrew. tap.linux? requires
shelling out to git and is only needed on macOS.