### PR TITLE
formula_installer: Use bottle_dependencies

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -583,11 +583,7 @@ class FormulaInstaller
     elsif !deps.empty?
       oh1 "Installing dependencies for #{formula.full_name}: #{deps.map(&:first).map(&Formatter.method(:identifier)).join(", ")}",
         truncate: false
-      deps.each do |dep, options|
-        # Fix for patchelf
-        next if formula.full_name == dep.to_formula.full_name
-        install_dependency(dep, options)
-      end
+      deps.each { |dep, options| install_dependency(dep, options) }
     end
 
     @show_header = true unless deps.empty?

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -18,6 +18,8 @@ describe FormulaInstaller do
     expect(formula).to pour_bottle
 
     stub_formula_loader formula
+    stub_formula_loader formula("gcc") { url "gcc-1.0" }
+    stub_formula_loader formula("glibc") { url "glibc-1.0" }
     stub_formula_loader formula("patchelf") { url "patchelf-1.0" }
     allow(Formula["patchelf"]).to receive(:installed?).and_return(true)
     described_class.new(formula).install


### PR DESCRIPTION
Modify `bottle_dependencies` to use `Keg.relocation_formulae`.
Revert `Fix dependency cycle when install patchelf`.