### PR TITLE
update-report: Work around an unusual error

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -62,10 +62,10 @@ module Homebrew
       updated = true
     end
 
-    initial_version = Version.new(system_command!("git",
+    initial_version = Version.new(system_command("git",
                                                   args: ["describe", "--tags", "--abbrev=0", initial_revision],
                                                   chdir: HOMEBREW_REPOSITORY,
-                                                  print_stderr: false).stdout)
+                                                  print_stderr: true).stdout)
 
     updated_taps = []
     Tap.each do |tap|


### PR DESCRIPTION
Work around the following error:

```
Error: Failure while executing; `git describe --tags --abbrev=0 bf1184bc9b8b1a7194efa23ff4f4323b243fdf44` exited with 128. Here's the output:
fatal: No names found, cannot describe anything.
Error: Failure while executing; `brew update` exited with 1.
```