### PR TITLE
superenv: Use 02 optimization flag for Linux builds

### DIFF
--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -9,6 +9,7 @@ module Superenv
   # @private
   def setup_build_environment(formula = nil)
     generic_setup_build_environment(formula)
+    self["HOMEBREW_OPTIMIZATION_LEVEL"] = "O2"
     self["HOMEBREW_DYNAMIC_LINKER"] = determine_dynamic_linker_path
     self["HOMEBREW_RPATH_PATHS"] = determine_rpath_paths(formula)
   end


### PR DESCRIPTION
See https://github.com/Linuxbrew/homebrew-core/issues/8405

`Os` produces bigger binaries on Linux (at least for llvm).
It produces also slower binaries in some cases.

Using `02` aligns us with what Debian does, and as we are compiling most of our stuff with gcc (and not clang), it makes sense to use `02` on Linux.
`Os` does probably slightly different things when used on mac with llvm, compared to when it is used with gcc on Linux.