### PR TITLE
Revert "cask: Only enable on macOS"

### DIFF
--- a/Library/Homebrew/cmd/cask.rb
+++ b/Library/Homebrew/cmd/cask.rb
@@ -4,7 +4,6 @@ module Homebrew
   module_function
 
   def cask
-    odie "Homebrew Cask is only supported on macOS" unless OS.mac?
     Hbc::CLI.run(*ARGV)
   end
 end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -106,7 +106,7 @@ module Homebrew
     begin
       formulae = []
 
-      if OS.mac? && !ARGV.casks.empty?
+      unless ARGV.casks.empty?
         args = []
         args << "--force" if ARGV.force?
         args << "--debug" if ARGV.debug?


### PR DESCRIPTION
This reverts commit fe7caf7cd8a413fb1118f6149ac2cf3acafd63de.

Brew gives an error message for `brew cask install`.
```
Error: Installing casks is supported only on macOS
```