### PR TITLE
uses: Revert HOMEBREW_VERBOSE_USING_DOTS

### DIFF
--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -50,17 +50,7 @@ module Homebrew
 
     includes, ignores = argv_includes_ignores(ARGV)
 
-    verbose_using_dots = !ENV["HOMEBREW_VERBOSE_USING_DOTS"].nil?
-    last_dot = Time.at(0)
-
     uses = formulae.select do |f|
-      # Print a dot every minute.
-      if verbose_using_dots && (Time.now - last_dot) > 60
-        last_dot = Time.now
-        $stderr.print "."
-        $stderr.flush
-      end
-
       used_formulae.all? do |ff|
         begin
           deps = f.runtime_dependencies if only_installed_arg
@@ -84,7 +74,6 @@ module Homebrew
         end
       end
     end
-    $stderr.puts if verbose_using_dots
 
     return if uses.empty?
     puts Formatter.columns(uses.map(&:full_name).sort)

--- a/Library/Homebrew/test/cmd/uses_spec.rb
+++ b/Library/Homebrew/test/cmd/uses_spec.rb
@@ -7,23 +7,19 @@ describe "brew uses", :integration_test do
       depends_on "bar"
     RUBY
 
-    # This test would fail when HOMEBREW_VERBOSE_USING_DOTS is set,
-    # as is the case on Linuxbrew's Travis. Rather than convolute
-    # logic, just force that variable to be on and change the
-    # expectation.
-    expect { brew "uses", "baz", "HOMEBREW_VERBOSE_USING_DOTS" => "1" }
+    expect { brew "uses", "baz" }
       .to be_a_success
       .and not_to_output.to_stdout
-      .and output(".\n").to_stderr
+      .and not_to_output.to_stderr
 
-    expect { brew "uses", "bar", "HOMEBREW_VERBOSE_USING_DOTS" => "1" }
+    expect { brew "uses", "bar" }
       .to output("baz\n").to_stdout
-      .and output(".\n").to_stderr
+      .and not_to_output.to_stderr
       .and be_a_success
 
-    expect { brew "uses", "--recursive", "foo", "HOMEBREW_VERBOSE_USING_DOTS" => "1" }
+    expect { brew "uses", "--recursive", "foo" }
       .to output(/(bar\nbaz|baz\nbar)/).to_stdout
-      .and output(".\n").to_stderr
+      .and not_to_output.to_stderr
       .and be_a_success
   end
 end


### PR DESCRIPTION
Reverts PR Linuxbrew/brew#217.
Reverts commit 0587e35548a85c4eedb36bf24fc6e169397f236c.

brew uses is now fast enough.