### PR TITLE
Revert "system_command_spec.rb: require system_command"

### DIFF
--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -1,5 +1,3 @@
-require "system_command"
-
 describe SystemCommand do
   describe "#initialize" do
     let(:env_args) { ["bash", "-c", 'printf "%s" "${A?}" "${B?}" "${C?}"'] }


### PR DESCRIPTION
This reverts commit 8be328f8aa96fbe641366e840fffce5cd69b8134.

This change appears unnecessary.