### PR TITLE
Revert "analytics.sh: Fix missing git for Linuxbrew"

### DIFF
--- a/Library/Homebrew/utils/analytics.sh
+++ b/Library/Homebrew/utils/analytics.sh
@@ -15,7 +15,6 @@ migrate-legacy-uuid-file() {
 
 setup-analytics() {
   local git_config_file="$HOMEBREW_REPOSITORY/.git/config"
-  test -r $git_config_file || return
 
   migrate-legacy-uuid-file
 


### PR DESCRIPTION
This reverts commit 2346031d3ca32da5e18b375221f7076f0f2a8bf2.

This change is no longer needed.