### PR TITLE
Use Coretap.instance.slug when reporting brew version

### DIFF
--- a/Library/Homebrew/cmd/--version.rb
+++ b/Library/Homebrew/cmd/--version.rb
@@ -8,6 +8,6 @@ module Homebrew
     odie "This command does not take arguments." if ARGV.any?
 
     puts "Homebrew #{HOMEBREW_VERSION}"
-    puts "Homebrew/homebrew-core #{CoreTap.instance.version_string}"
+    puts "#{CoreTap.instance.slug} #{CoreTap.instance.version_string}"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Linuxbrew uses Linuxbrew/homebrew-core as its core tap, so it is incorrect to tell users that they're using Homebrew/homebrew-core tap. This PR fixes it.