### PR TITLE
Patching the dynamic linker of glibc breaks it

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -1,5 +1,8 @@
 class Keg
   def relocate_dynamic_linkage(relocation)
+    # Patching the dynamic linker of glibc breaks it.
+    return if name == "glibc"
+
     # Patching patchelf using itself fails with "Text file busy" or SIGBUS.
     return if name == "patchelf"
 


### PR DESCRIPTION
This bug was introduced in Linuxbrew/brew 1.6.15 when this line was removed:
https://github.com/Linuxbrew/brew/blob/87dea507dee356937b2a55d0e74b13365c5a1203/Library/Homebrew/extend/os/linux/keg_relocate.rb#L2-L3

See https://github.com/Linuxbrew/homebrew-core/issues/8951