### PR TITLE
test: Work around test failure on CircleCI macOS

### DIFF
--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -43,7 +43,7 @@ RSpec.shared_context "integration test" do
 
       example.run
     ensure
-      FileUtils.rm HOMEBREW_PREFIX/"bin/brew"
+      FileUtils.rm_f HOMEBREW_PREFIX/"bin/brew"
       FileUtils.rmdir HOMEBREW_PREFIX/"bin"
     end
   end


### PR DESCRIPTION
```
1) brew install can install HEAD Formulae
     Failure/Error: File.unlink path
     Errno::ENOENT:
       No such file or directory @ unlink_internal - /tmp/homebrew-tests-20180823-5420-1s34o8z/prefix/bin/brew
     # ./test/support/helper/spec/shared_context/integration_test.rb:46:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:121:in `block (2 levels) in <top (required)>'
```