### PR TITLE
Keep path to JDK

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -242,6 +242,9 @@ class Cmd
       false
     elsif mac?
       true
+    elsif path.start_with?("/usr/lib/jvm")
+      # keep path to JDK
+      true
     else
       false
     end


### PR DESCRIPTION
To compile JNI code that requires` <jni.h>` header to include, keeping path to JDK `/usr/lib/jvm/` is necessary.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
