### PR TITLE
configure-shell: remove HOMEBREW paths before adding

### DIFF
--- a/Library/Homebrew/cmd/configure-shell.rb
+++ b/Library/Homebrew/cmd/configure-shell.rb
@@ -14,6 +14,20 @@ module Homebrew
     brew_env = <<~EOS
       # Homebrew environment
       # Created by running brew configure-shell
+      pathremove () {
+        local IFS=':' NEWPATH="" DIR="" PATHVARIABLE=${2:-PATH}
+        for DIR in ${!PATHVARIABLE} ; do
+          if [ "$DIR" != "$1" ] ; then
+            NEWPATH=${NEWPATH:+$NEWPATH:}$DIR
+          fi
+        done
+        export $PATHVARIABLE="$NEWPATH"
+      }
+      pathremove "#{HOMEBREW_PREFIX}/bin"
+      pathremove "#{HOMEBREW_PREFIX}/sbin"
+      pathremove "#{HOMEBREW_PREFIX}/share/man" MANPATH
+      pathremove "#{HOMEBREW_PREFIX}/share/info" INFOPATH
+
       export PATH="#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:$PATH"
       export MANPATH="#{HOMEBREW_PREFIX}/share/man:$MANPATH"
       export INFOPATH="#{HOMEBREW_PREFIX}/share/info:$INFOPATH"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

User can add Homebrew/Linuxbrew PATHs in many ways. This is a proposal to remove Homebrew/Linuxbrew paths before adding them.