### PR TITLE
Doctor check umask

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -48,6 +48,19 @@ module Homebrew
             #{Utils::Shell.prepend_variable_in_profile("XDG_DATA_DIRS", HOMEBREW_PREFIX/"share")}
         EOS
       end
+
+      def check_umask_not_zero
+        return unless File.umask() == 0
+
+        <<~EOS
+          Umask is currently set to 000, directories created by Homebrew cannot
+          be world-writable. There is a known issue in Windows Subsytem for
+          Linux where this occurs. This can be resolved by adding umask 002 to
+          your #{shell_profile},
+          For example:
+            echo 'umask 002' >> #{shell_profile}
+        EOS
+      end
     end
   end
 end

--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -50,7 +50,7 @@ module Homebrew
       end
 
       def check_umask_not_zero
-        return unless File.umask() == 0
+        return unless File.umask == 0
 
         <<~EOS
           Umask is currently set to 000, directories created by Homebrew cannot

--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -50,7 +50,7 @@ module Homebrew
       end
 
       def check_umask_not_zero
-        return unless File.umask == 0
+        return unless File.umask.zero?
 
         <<~EOS
           Umask is currently set to 000, directories created by Homebrew cannot


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Users on Window Subsystem for Linux have a umask of 000 when logging into their shell causing a [sticky bit error](https://github.com/Linuxbrew/brew/issues/852) when updating and installing packages in Linuxbrew.  This is a [known issue](https://github.com/Microsoft/WSL/issues/352) in WSL.
 
This PR adds a check to `brew doctor` warning users if their umask is 000, and how to resolve it.