### PR TITLE
docker.test.yml: Use brew tests [Linux]

### DIFF
--- a/docker.test.yml
+++ b/docker.test.yml
@@ -1,7 +1,3 @@
 sut:
   build: .
-  command: sh -c 'git -C /home/linuxbrew/.linuxbrew/Homebrew fetch --tags --unshallow && brew test-bot'
-  environment:
-    - GIT_BRANCH
-    - GIT_SHA1
-    - HOMEBREW_DEVELOPER=1
+  command: sh -c 'brew doctor && brew tests'


### PR DESCRIPTION
Use `brew doctor && brew tests` rather than `brew test-bot`, which is taking longer than two hours on Docker Hub.