### PR TITLE
bin/brew: remove bash redirection

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -1,8 +1,4 @@
-#!/bin/sh
-if [ -z "$BASH_VERSION" ]
-then
-  exec bash "$0" "$@"
-fi
+#!/bin/bash
 set +o posix
 
 # Fail fast with concise message when cwd does not exist


### PR DESCRIPTION
This was added back then to allow to run brew if you had no /bin/bash.
There are now multiple places in the code where /bin/bash is hardcoded,
which makes this change useless without fixing the other places.

If needed we can try to provide a better solution later on, but I think
removing this allows to have one patch less to backport to Homebrew.
