### PR TITLE
Migrate from Linuxbrew/brew to Homebrew/brew

### DIFF
--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -38,6 +38,7 @@ homebrew-update-reset() {
     echo "==> Fetching $DIR..."
 
     if [[ "$DIR" = "$HOMEBREW_REPOSITORY" ]]; then
+      git config remote.origin.url "https://github.com/Homebrew/brew"
       latest_tag="$(git ls-remote --tags --refs -q origin | tail -n1 | cut -f2)"
       git fetch --force origin --shallow-since="$latest_tag"
     else


### PR DESCRIPTION
Linuxbrew/brew has been merged into Homebrew/brew!
Linuxbrew/brew will no longer be updated.
See the blog post at https://brew.sh/2019/02/02/homebrew-2.0.0/